### PR TITLE
Add support for NN-FBP and N2F denoisers

### DIFF
--- a/corrct/denoisers.py
+++ b/corrct/denoisers.py
@@ -14,9 +14,20 @@ from . import data_terms
 from . import regularizers
 from . import solvers
 from . import utils_reg
+from . import filters
+from . import utils_proc
 
-from typing import Optional, Tuple, Union, Callable
+try:
+    from . import utils_nn
 
+    has_nn = True
+
+except ImportError as ex:
+    print(ex)
+
+    has_nn = False
+
+from typing import List, Optional, Tuple, Union, Callable
 from numpy.typing import ArrayLike, NDArray
 
 
@@ -105,3 +116,105 @@ def denoise_image(
     (denoised_img, _) = solver_call(solver, None)
 
     return denoised_img
+
+
+class Denoiser_NNFBP:
+    """Denoise FBP using Neural Networks."""
+
+    projector: operators.BaseTransform
+    num_fbps: int
+    hidden_layers: List[int]
+
+    def __init__(
+        self,
+        projector: operators.BaseTransform,
+        num_fbps: int = 4,
+        num_pixels_train: int = 256,
+        num_pixels_test: int = 64,
+        hidden_layers: List[int] = list(),
+    ) -> None:
+        if not has_nn:
+            raise RuntimeError("Neural network module not available!")
+        self.projector = projector
+        self.num_fbps = num_fbps
+        self.num_pixels_train = num_pixels_train
+        self.num_pixels_test = num_pixels_test
+        self.hidden_layers = hidden_layers
+
+        self.filters = filters.FilterCustom([1.0])
+
+    def _get_normalization(self, vol: NDArray, percentile: Optional[float] = None) -> Tuple[float, float]:
+        if percentile is not None:
+            vol_sort = np.sort(vol.flatten())
+            ind_min = np.fmax(int(vol_sort.size * percentile), 0)
+            ind_max = np.fmin(int(vol_sort.size * (1 - percentile)), vol_sort.size - 1)
+            return vol_sort[ind_min], vol_sort[ind_max]
+        else:
+            return vol.min(), vol.max()
+
+    def _sub_sample_pixels(
+        self, num_pixels: int, lq_recs: List[NDArray], hq_recs: NDArray, hq_weights: Optional[NDArray] = None
+    ) -> utils_nn.DatasetPixel:
+        vol_mask = utils_proc.get_circular_mask(hq_recs.shape)
+        vol_linear_pos = np.arange(vol_mask.size)[vol_mask.flatten() == 1.0]
+
+        pixels_pos = np.random.permutation(int(np.sum(vol_mask)))[:num_pixels]
+        pixels_pos = vol_linear_pos[pixels_pos]
+
+        X = np.stack([lq_rec.flatten()[pixels_pos] for lq_rec in lq_recs], axis=-1)
+        y = hq_recs.flatten()[pixels_pos]
+
+        if hq_weights is None:
+            return utils_nn.DatasetPixel(X, y)
+        else:
+            w = hq_weights.flatten()[pixels_pos]
+            return utils_nn.DatasetPixel(X, y, w)
+
+    def compute_filter(self, lq_sinos: NDArray, hq_recs: NDArray, hq_weights: Optional[NDArray] = None) -> None:
+        num_pixels = self.filters.get_padding_size(lq_sinos.shape)
+        self.basis_r = filters.create_basis(num_pixels, binning_start=3, binning_type="exponential", normalized=True)
+        self.basis_f = self.filters.to_fourier(self.basis_r)
+        self.filters = filters.FilterCustom(self.basis_f)
+
+        num_filters = self.filters.num_filters
+
+        lq_sinos_filt = self.filters.apply_filter(lq_sinos)
+        lq_recs = [np.array([])] * num_filters
+        for ii in range(num_filters):
+            lq_recs[ii] = self.projector.T(lq_sinos_filt[ii])
+
+        # Compute scaling
+        min_max_features = [self._get_normalization(lq_rec) for lq_rec in lq_recs]
+        self.min_max_target = self._get_normalization(hq_recs)
+
+        lq_recs = [lq_rec / (max - min) for lq_rec, (min, max) in zip(lq_recs, min_max_features)]
+        hq_recs = hq_recs / (self.min_max_target[1] - self.min_max_target[0])
+
+        dset_train = self._sub_sample_pixels(self.num_pixels_train, lq_recs, hq_recs, hq_weights)
+        dset_test = self._sub_sample_pixels(self.num_pixels_test, lq_recs, hq_recs, hq_weights)
+
+        self.nn_fit = utils_nn.NeuralNetwork(layers_size=[num_filters, self.num_fbps, *self.hidden_layers, 1])
+        self.nn_fit.train(dset_train, dataset_test=dset_test)
+
+        w, b = self.nn_fit.model.get_weights()
+        new_filters = [filt / (max - min) for filt, (min, max) in zip(self.filters.filter_fourier, min_max_features)]
+        filters_learned = w[0].dot(new_filters)
+
+        self.filters = filters.FilterCustom(filters_learned)
+        w[0] = np.eye(self.num_fbps)
+
+        self.nn_predict = utils_nn.NeuralNetwork(layers_size=[self.num_fbps, self.num_fbps, *self.hidden_layers, 1])
+        self.nn_predict.model.set_weights(w, b)
+
+    def apply_filter(self, lq_sinos: NDArray) -> NDArray:
+        lq_sinos_filt = self.filters.apply_filter(lq_sinos)
+        lq_recs = [np.array([])] * self.filters.num_filters
+        for ii in range(self.filters.num_filters):
+            lq_recs[ii] = self.projector.T(lq_sinos_filt[ii])
+
+        lq_recs_stack = np.stack([lq_rec.flatten() for lq_rec in lq_recs], axis=-1)
+        dset_predict = utils_nn.DatasetPixel(lq_recs_stack)
+
+        hq_rec = self.nn_predict.predict(dset_predict)
+        hq_rec *= self.min_max_target[1] - self.min_max_target[0]
+        return hq_rec.reshape(lq_recs[0].shape)

--- a/corrct/utils_nn.py
+++ b/corrct/utils_nn.py
@@ -111,7 +111,7 @@ class NeuralNetwork:
         self,
         layers_size: Sequence[int],
         device: str = "cuda" if tcd.is_available() else "cpu",
-        batch_size: int = 128,
+        batch_size: int = 512,
     ) -> None:
         self.layers_size = layers_size
 
@@ -119,14 +119,14 @@ class NeuralNetwork:
         self.batch_size = batch_size
         self.model = ModelNetwork(self.layers_size).to(self.device)
 
-    def train(self, dataset_train: tdt.Dataset, iterations: int = 10000, dataset_test: Optional[tdt.Dataset] = None):
+    def train(self, dataset_train: tdt.Dataset, iterations: int = 10_000, dataset_test: Optional[tdt.Dataset] = None):
         dataloader_train = tdt.DataLoader(dataset_train, batch_size=self.batch_size)
         datasize_train = len(dataloader_train.dataset)
         if dataset_test is not None:
             dataloader_test = tdt.DataLoader(dataset_test, batch_size=self.batch_size)
             datasize_test = len(dataloader_test.dataset)
         loss_fn = tnn.MSELoss(reduction="sum")
-        optimizer = top.Adam(self.model.parameters(), lr=1e-3)
+        optimizer = top.AdamW(self.model.parameters(), lr=1e-3)
 
         self.model.train()
         for ii in range(iterations):

--- a/corrct/utils_nn.py
+++ b/corrct/utils_nn.py
@@ -10,15 +10,16 @@ import numpy as np
 
 from collections import OrderedDict
 
-from typing import List, Optional, Sequence, Tuple
+from typing import Callable, List, Optional, Sequence, Tuple, Union
 from numpy.typing import NDArray
-
 
 import torch as pt
 from torch import nn as tnn
 from torch.utils import data as tdt
 from torch import cuda as tcd
 from torch import optim as top
+
+from tqdm import tqdm
 
 
 eps = np.finfo(np.float32).eps
@@ -45,28 +46,26 @@ class DatasetPixel(tdt.Dataset):
             return self.inp_vals[idx, :]
 
 
-class ModelNetwork(tnn.Module):
+class Model(tnn.Module):
     """Neural network model class."""
 
-    def __init__(self, layers_size: Sequence[int], linears_labels: Optional[Sequence[str]] = None):
-        super(ModelNetwork, self).__init__()
+    def __init__(self, layers_size: Sequence[int], problem_type: str = "regression"):
+        super(Model, self).__init__()
 
         self.linears_dims = [(layers_size[ii], layers_size[ii + 1]) for ii in range(len(layers_size) - 1)]
 
         tmp_op_stack = OrderedDict()
         for ii, (i, o) in enumerate(self.linears_dims):
-            if linears_labels is None:
-                lab = f"linear_{ii}"
-            else:
-                lab = linears_labels[ii]
+            lab = f"linear_{ii}"
             tmp_op_stack[lab] = tnn.Linear(i, o)
             tmp_op_stack.move_to_end(lab)
 
-            lab = f"activation_{ii}"
-            # tmp_op_stack[lab] = tnn.Sigmoid()
-            tmp_op_stack[lab] = tnn.GELU()
-            # tmp_op_stack[lab] = tnn.ReLU()
-            tmp_op_stack.move_to_end(lab)
+            if ii < (len(self.linears_dims) - 1) or problem_type == "classification":
+                lab = f"activation_{ii}"
+                tmp_op_stack[lab] = tnn.Sigmoid()
+                # tmp_op_stack[lab] = tnn.GELU()
+                # tmp_op_stack[lab] = tnn.ReLU()
+                tmp_op_stack.move_to_end(lab)
 
         lab = f"flatten"
         tmp_op_stack[lab] = tnn.Flatten(0, 1)
@@ -103,6 +102,55 @@ class ModelNetwork(tnn.Module):
 
         return weights, biases
 
+    def orthogonalize_layer(
+        self, layer: Union[int, Sequence[int], None] = None, weight: float = 1.0, normalized: bool = False
+    ) -> None:
+        w, b = self.get_weights()
+
+        if layer is None:
+            layer = [*range(len(w))]
+        elif not isinstance(layer, Sequence):
+            layer = [layer]
+
+        for l in layer:
+            for ii in range(1, w[l].shape[0]):
+                for jj in range(0, ii):
+                    other_vec = w[l][jj, ...]
+                    w[l][ii, ...] -= weight * other_vec * other_vec.dot(w[l][ii, ...]) / other_vec.dot(other_vec)
+
+            if normalized:
+                w[l] /= np.linalg.norm(w[l], ord=1, axis=-1, keepdims=True)
+
+        self.set_weights(w, b)
+
+    def normalize_layer(self, layer: int, axis: int = 0, norm: int = 2) -> None:
+        w, b = self.get_weights()
+
+        norms = np.linalg.norm(w[layer], axis=axis, keepdims=True, ord=norm)
+        w[layer] /= norms / np.mean(norms)
+
+        self.set_weights(w, b)
+
+
+class TrainingInfo:
+    """Training report object."""
+
+    loss_values_trn: NDArray
+    loss_values_tst: NDArray
+
+    loss_init_tst: float
+
+    init_weights: Tuple[Sequence[NDArray], Sequence[NDArray]]
+    best_weights: Tuple[Sequence[NDArray], Sequence[NDArray]]
+
+    def __init__(self, epochs: int, loss_tst: float, weights: Tuple[Sequence[NDArray], Sequence[NDArray]]) -> None:
+        self.loss_values_trn = np.zeros(epochs)
+        self.loss_values_tst = np.zeros(epochs)
+
+        self.loss_init_tst = loss_tst
+
+        self.init_weights = self.best_weights = weights
+
 
 class NeuralNetwork:
     """Neural Network proxy object."""
@@ -113,35 +161,98 @@ class NeuralNetwork:
         self,
         layers_size: Sequence[int],
         device: str = "cuda" if tcd.is_available() else "cpu",
-        batch_size: int = 512,
+        batch_size_default: int = 2**20,
     ) -> None:
         self.layers_size = layers_size
 
         self.device = device
-        self.batch_size = batch_size
-        self.model = ModelNetwork(self.layers_size).to(self.device)
+        self.batch_size_default = batch_size_default
+        self.model = Model(self.layers_size).to(self.device)
 
-    def train(self, dataset_train: tdt.Dataset, iterations: int = 10_000, dataset_test: Optional[tdt.Dataset] = None):
-        dataloader_train = tdt.DataLoader(dataset_train, batch_size=self.batch_size)
-        datasize_train = len(dataloader_train.dataset)
-        if dataset_test is not None:
-            dataloader_test = tdt.DataLoader(dataset_test, batch_size=self.batch_size)
-            datasize_test = len(dataloader_test.dataset)
+    def train_adam(
+        self,
+        data_train: Sequence[NDArray],
+        data_test: Sequence[NDArray],
+        batch_size: int = 2**8,
+        iterations: int = 10_000,
+        encourage_orthogonal: bool = True,
+    ) -> TrainingInfo:
+        return self.train(
+            data_train,
+            data_test,
+            iterations=iterations,
+            batch_size=batch_size,
+            optim_class=top.AdamW,
+            encourage_orthogonal=encourage_orthogonal,
+        )
+
+    def train_lbfgs(
+        self,
+        data_train: Sequence[NDArray],
+        data_test: Sequence[NDArray],
+        batch_size: int = 2**20,
+        iterations: int = 10_000,
+        encourage_orthogonal: bool = False,
+    ) -> TrainingInfo:
+        return self.train(
+            data_train,
+            data_test,
+            iterations=iterations,
+            batch_size=batch_size,
+            optim_class=lambda *x, **y: top.LBFGS(*x, **y, max_iter=1000, history_size=200),
+            encourage_orthogonal=encourage_orthogonal,
+        )
+
+    def train(
+        self,
+        data_train: Sequence[NDArray],
+        data_test: Sequence[NDArray],
+        optim_class: Callable = top.AdamW,
+        batch_size: Optional[int] = None,
+        iterations: int = 10_000,
+        encourage_orthogonal: bool = True,
+        verbose: bool = True,
+    ) -> TrainingInfo:
+        dataset_train = DatasetPixel(*data_train)
+        dataset_test = DatasetPixel(*data_test)
+
+        datasize_train = len(dataset_train)
+        datasize_test = len(dataset_test)
+
+        if batch_size is None:
+            batch_size = self.batch_size_default
+
+        dataloader_train = tdt.DataLoader(dataset_train, batch_size=batch_size)
+        dataloader_test = tdt.DataLoader(dataset_test, batch_size=batch_size)
+
         loss_fn = tnn.MSELoss(reduction="none")
-        learning_rate = 1e-3
-        optimizer = top.AdamW(self.model.parameters(), lr=learning_rate, weight_decay=1e-2)
 
-        self.model.train()
-        for ii in range(iterations):
+        learning_rate = 1e-3
+        optimizer = optim_class(self.model.parameters(), lr=learning_rate)
+        scheduler = top.lr_scheduler.ReduceLROnPlateau(optimizer, "min", factor=0.5, min_lr=learning_rate * 1e-2)
+
+        best_loss_test = self._test(dataloader_test, datasize_test, loss_fn)
+        best_epoch = -1
+
+        info = TrainingInfo(epochs=iterations, loss_tst=best_loss_test, weights=self.model.get_weights())
+
+        scheduler.step(best_loss_test)
+
+        if verbose:
+            print(f"Initial test loss: {best_loss_test:>7f}")
+
+        for ii in tqdm(range(iterations)):
+            self.model.train()
             loss_train = 0.0
             for bunch_train in dataloader_train:
                 has_weights = len(bunch_train) == 3
                 if has_weights:
                     X, y, w = bunch_train
-                    w = w.to(self.device)
+                    w = w.to(self.device, non_blocking=True)
                 else:
                     X, y = bunch_train
-                X, y = X.to(self.device), y.to(self.device)
+                X = X.to(self.device, non_blocking=True)
+                y = y.to(self.device, non_blocking=True)
 
                 def closure():
                     if pt.is_grad_enabled():
@@ -152,7 +263,7 @@ class NeuralNetwork:
                     loss = loss_fn(pred_y, y)
 
                     if has_weights:
-                        loss *= w / w.mean()
+                        loss *= w
                     loss = loss.sum()
 
                     # Backpropagation
@@ -160,50 +271,73 @@ class NeuralNetwork:
                         loss.backward()
                     return loss
 
+                if encourage_orthogonal:
+                    self.model.orthogonalize_layer(layer=0, weight=learning_rate * 1e-2)
+
                 loss = optimizer.step(closure=closure)
 
                 loss_train += loss.item()
             loss_train /= datasize_train
 
-            if ii % 100 == 0:
-                if dataset_test is not None:
-                    loss_test = 0.0
-                    for bunch_test in dataloader_test:
-                        has_weights = len(bunch_test) == 3
-                        if has_weights:
-                            X, y, w = bunch_test
-                        else:
-                            X, y = bunch_test
-                        X, y = X.to(self.device), y.to(self.device)
+            curr_loss_test = self._test(dataloader_test, datasize_test, loss_fn)
 
-                        pred_y = self.model(X)
-                        loss = loss_fn(pred_y, y)
-                        if has_weights:
-                            w = w.to(self.device)
-                            loss *= w / w.mean()
-                        loss_test += loss.sum().item()
-                    loss_test /= datasize_test
-                else:
-                    loss_test = np.NaN
-                print(f"{ii}-{iterations} loss: {loss_train:>7f}  [test: {loss_test:>7f}]")
+            scheduler.step(curr_loss_test)
 
-    def test(self, dataset: tdt.Dataset):
-        dataloader = tdt.DataLoader(dataset, batch_size=self.batch_size)
-        loss_fn = tnn.MSELoss(reduction="sum")
+            if curr_loss_test < best_loss_test:
+                best_loss_test = curr_loss_test
+                best_epoch = ii
+                info.best_weights = self.model.get_weights()
 
-        datasize = len(dataloader.dataset)
+            info.loss_values_trn[ii] = loss_train
+            info.loss_values_tst[ii] = curr_loss_test
+
+            if verbose and ii % 20 == 0:
+                grad_avg_val = np.max([param.grad.mean() for _, param in self.model.named_parameters()])
+                print(f"{ii}-{iterations} loss: {loss_train:>6f}  [test: {curr_loss_test:>7f}, avg grad: {grad_avg_val:>4f}]")
+
+        if verbose:
+            print(f"Using weights from epoch {best_epoch}, with loss: {best_loss_test:>7f}")
+
+        self.model.set_weights(*info.best_weights)
+
+        return info
+
+    def _test(self, dataloader: tdt.DataLoader, datasize: int, loss_fn: tnn.Module) -> float:
         self.model.eval()
-        test_loss = 0
-        with pt.no_grad():
-            for X, y in dataloader:
-                X, y = X.to(self.device), y.to(self.device)
-                pred = self.model(X)
-                loss = loss_fn(pred, y)
-                test_loss += loss.item()
-        test_loss /= datasize
-        print(f"Test Error: \n Avg loss: {test_loss:>8f} \n")
+        loss_test = 0.0
+        with pt.inference_mode():
+            for bunch_test in dataloader:
+                has_weights = len(bunch_test) == 3
+                if has_weights:
+                    X, y, w = bunch_test
+                    w = w.to(self.device, non_blocking=True)
+                else:
+                    X, y = bunch_test
+                X = X.to(self.device, non_blocking=True)
+                y = y.to(self.device, non_blocking=True)
 
-    def predict(self, dataset: tdt.Dataset) -> NDArray:
-        dataloader = tdt.DataLoader(dataset, batch_size=self.batch_size)
-        with pt.no_grad():
+                pred_y = self.model(X)
+                loss = loss_fn(pred_y, y)
+                if has_weights:
+                    loss *= w
+                loss_test += loss.sum().item()
+
+        return loss_test / datasize
+
+    def test(self, data: Sequence[NDArray], verbose: bool = False) -> float:
+        dataset_test = DatasetPixel(*data)
+        dataloader_test = tdt.DataLoader(dataset_test, batch_size=self.batch_size_default)
+
+        loss_test = self._test(dataloader_test, datasize=len(dataset_test), loss_fn=tnn.MSELoss(reduction="none"))
+
+        if verbose:
+            print(f"Test Error: \n Avg loss: {loss_test:>8f} \n")
+
+        return loss_test
+
+    def predict(self, data: Sequence[NDArray]) -> NDArray:
+        dataset = DatasetPixel(*data)
+        dataloader = tdt.DataLoader(dataset, batch_size=self.batch_size_default)
+        self.model.eval()
+        with pt.inference_mode():
             return np.concatenate([self.model(X).numpy() for X in dataloader])

--- a/corrct/utils_nn.py
+++ b/corrct/utils_nn.py
@@ -27,22 +27,22 @@ eps = np.finfo(np.float32).eps
 class DatasetPixel(tdt.Dataset):
     """Dataset class for various learned methods."""
 
-    def __init__(self, filter_vals: NDArray, pixel_vals: Optional[NDArray] = None, pixel_weights: Optional[NDArray] = None):
-        self.filter_values = pt.tensor(filter_vals, dtype=pt.float)
-        self.pixel_values = pt.tensor(pixel_vals, dtype=pt.float) if pixel_vals is not None else None
-        self.pixel_weights = pt.tensor(pixel_weights, dtype=pt.float) if pixel_weights is not None else None
+    def __init__(self, inp_vals: NDArray, tgt_vals: Optional[NDArray] = None, tgt_wgts: Optional[NDArray] = None):
+        self.inp_vals = pt.tensor(inp_vals, dtype=pt.float)
+        self.tgt_vals = pt.tensor(tgt_vals, dtype=pt.float) if tgt_vals is not None else None
+        self.tgt_wgts = pt.tensor(tgt_wgts, dtype=pt.float) if tgt_wgts is not None else None
 
     def __len__(self):
-        return self.filter_values.shape[0]
+        return self.inp_vals.shape[0]
 
     def __getitem__(self, idx):
-        if self.pixel_values is not None:
-            if self.pixel_weights is not None:
-                return self.filter_values[idx, :], self.pixel_values[idx], self.pixel_weights[idx]
+        if self.tgt_vals is not None:
+            if self.tgt_wgts is not None:
+                return self.inp_vals[idx, :], self.tgt_vals[idx], self.tgt_wgts[idx]
             else:
-                return self.filter_values[idx, :], self.pixel_values[idx]
+                return self.inp_vals[idx, :], self.tgt_vals[idx]
         else:
-            return self.filter_values[idx, :]
+            return self.inp_vals[idx, :]
 
 
 class ModelNetwork(tnn.Module):

--- a/corrct/utils_nn.py
+++ b/corrct/utils_nn.py
@@ -98,8 +98,8 @@ class ModelNetwork(tnn.Module):
         weights = [np.array([])] * len(self.linears_dims)
         biases = [np.array([])] * len(self.linears_dims)
         for ii in range(len(self.linears_dims)):
-            weights[ii] = tmp_op_stack[f"linear_{ii}.weight"].numpy()
-            biases[ii] = tmp_op_stack[f"linear_{ii}.bias"].numpy()
+            weights[ii] = tmp_op_stack[f"linear_{ii}.weight"].numpy().copy()
+            biases[ii] = tmp_op_stack[f"linear_{ii}.bias"].numpy().copy()
 
         return weights, biases
 

--- a/corrct/utils_nn.py
+++ b/corrct/utils_nn.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""
+Neural network support module.
+
+@author: Nicola VIGANÒ, Computational Imaging group, CWI, The Netherlands,
+and ESRF - The European Synchrotron, Grenoble, France
+"""
+
+import numpy as np
+
+from collections import OrderedDict
+
+from typing import List, Optional, Sequence, Tuple
+from numpy.typing import NDArray
+
+
+import torch as pt
+from torch import nn as tnn
+from torch.utils import data as tdt
+from torch import cuda as tcd
+from torch import optim as top
+
+
+eps = np.finfo(np.float32).eps
+
+
+class DatasetPixel(tdt.Dataset):
+    """Dataset class for various learned methods."""
+
+    def __init__(self, filter_vals: NDArray, pixel_vals: Optional[NDArray] = None, pixel_weights: Optional[NDArray] = None):
+        self.filter_values = pt.tensor(filter_vals, dtype=pt.float)
+        self.pixel_values = pt.tensor(pixel_vals, dtype=pt.float) if pixel_vals is not None else None
+        self.pixel_weights = pt.tensor(pixel_weights, dtype=pt.float) if pixel_weights is not None else None
+
+    def __len__(self):
+        return self.filter_values.shape[0]
+
+    def __getitem__(self, idx):
+        if self.pixel_values is not None:
+            if self.pixel_weights is not None:
+                return self.filter_values[idx, :], self.pixel_values[idx], self.pixel_weights[idx]
+            else:
+                return self.filter_values[idx, :], self.pixel_values[idx]
+        else:
+            return self.filter_values[idx, :]
+
+
+class ModelNetwork(tnn.Module):
+    """Neural network model class."""
+
+    def __init__(self, layers_size: Sequence[int], linears_labels: Optional[List[str]] = None):
+        super(ModelNetwork, self).__init__()
+
+        self.linears_dims = [(layers_size[ii], layers_size[ii + 1]) for ii in range(len(layers_size) - 1)]
+
+        tmp_op_stack = OrderedDict()
+        for ii, (i, o) in enumerate(self.linears_dims):
+            if linears_labels is None:
+                lab = f"linear_{ii}"
+            else:
+                lab = linears_labels[ii]
+            tmp_op_stack[lab] = tnn.Linear(i, o)
+            tmp_op_stack.move_to_end(lab)
+
+            if ii < (len(self.linears_dims) - 1):
+                lab = f"relu_{ii}"
+                tmp_op_stack[lab] = tnn.ReLU()
+            else:
+                lab = f"flatten_{ii}"
+                tmp_op_stack[lab] = tnn.Flatten(0, 1)
+            tmp_op_stack.move_to_end(lab)
+
+        self.op_stack = tnn.Sequential(tmp_op_stack)
+
+    def forward(self, x):
+        return self.op_stack(x)
+
+    def set_weights(self, weights: List[NDArray], biases: List[NDArray]) -> None:
+        tmp_op_stack = self.op_stack.state_dict()
+        for ii, (iw, ib) in enumerate(zip(weights, biases)):
+            tw = tmp_op_stack[f"linear_{ii}.weight"]
+            tb = tmp_op_stack[f"linear_{ii}.bias"]
+
+            if tw.shape != iw.shape:
+                raise ValueError(f"The input weights at linear {ii} (shape: {iw.shape}) should have shape: {tw.shape}")
+            if tb.shape != ib.shape:
+                raise ValueError(f"The input bias at linear {ii} (shape: {ib.shape}) should have shape: {tb.shape}")
+
+            tmp_op_stack[f"linear_{ii}.weight"] = pt.tensor(iw)
+            tmp_op_stack[f"linear_{ii}.bias"] = pt.tensor(ib)
+
+        self.op_stack.load_state_dict(tmp_op_stack)
+
+    def get_weights(self) -> Tuple[List[NDArray], List[NDArray]]:
+        tmp_op_stack = self.op_stack.state_dict()
+        weights = [np.array([])] * len(self.linears_dims)
+        biases = [np.array([])] * len(self.linears_dims)
+        for ii in range(len(self.linears_dims)):
+            weights[ii] = tmp_op_stack[f"linear_{ii}.weight"].numpy()
+            biases[ii] = tmp_op_stack[f"linear_{ii}.bias"].numpy()
+
+        return weights, biases
+
+
+class NeuralNetwork:
+    """Neural Network proxy object."""
+
+    layers_size: Sequence[int]
+
+    def __init__(
+        self,
+        layers_size: Sequence[int],
+        device: str = "cuda" if tcd.is_available() else "cpu",
+        batch_size: int = 128,
+    ) -> None:
+        self.layers_size = layers_size
+
+        self.device = device
+        self.batch_size = batch_size
+        self.model = ModelNetwork(self.layers_size).to(self.device)
+
+    def train(self, dataset_train: tdt.Dataset, iterations: int = 10000, dataset_test: Optional[tdt.Dataset] = None):
+        dataloader_train = tdt.DataLoader(dataset_train, batch_size=self.batch_size)
+        datasize_train = len(dataloader_train.dataset)
+        if dataset_test is not None:
+            dataloader_test = tdt.DataLoader(dataset_test, batch_size=self.batch_size)
+            datasize_test = len(dataloader_test.dataset)
+        loss_fn = tnn.MSELoss(reduction="sum")
+        optimizer = top.Adam(self.model.parameters(), lr=1e-3)
+
+        self.model.train()
+        for ii in range(iterations):
+            loss_train = 0
+            for bunch_train in dataloader_train:
+                has_weights = len(bunch_train) == 3
+                if has_weights:
+                    X, y, w = bunch_train
+                else:
+                    X, y = bunch_train
+                X, y = X.to(self.device), y.to(self.device)
+
+                # Compute prediction error
+                pred_y = self.model(X)
+                if has_weights:
+                    w = w.to(self.device)
+                    y *= w
+                    pred_y *= w
+                loss = loss_fn(pred_y, y)
+
+                # Backpropagation
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+                loss_train += loss.item()
+            loss_train /= datasize_train
+
+            if ii % 100 == 0:
+                if dataset_test is not None:
+                    loss_test = 0
+                    for bunch_test in dataloader_test:
+                        has_weights = len(bunch_test) == 3
+                        if has_weights:
+                            X, y, w = bunch_test
+                        else:
+                            X, y = bunch_test
+                        X, y = X.to(self.device), y.to(self.device)
+
+                        pred_y = self.model(X)
+                        if has_weights:
+                            w = w.to(self.device)
+                            y *= w
+                            pred_y *= w
+                        loss_test += loss_fn(pred_y, y).item()
+                    loss_test /= datasize_test
+                else:
+                    loss_test = np.NaN
+                print(f"{ii}-{iterations} loss: {loss_train:>7f}  [test: {loss_test:>7f}]")
+
+    def test(self, dataset: tdt.Dataset):
+        dataloader = tdt.DataLoader(dataset, batch_size=self.batch_size)
+        loss_fn = tnn.MSELoss(reduction="sum")
+
+        datasize = len(dataloader.dataset)
+        self.model.eval()
+        test_loss = 0
+        with pt.no_grad():
+            for X, y in dataloader:
+                X, y = X.to(self.device), y.to(self.device)
+                pred = self.model(X)
+                test_loss += loss_fn(pred, y).item()
+        test_loss /= datasize
+        print(f"Test Error: \n Avg loss: {test_loss:>8f} \n")
+
+    def predict(self, dataset: tdt.Dataset) -> NDArray:
+        dataloader = tdt.DataLoader(dataset, batch_size=self.batch_size)
+        with pt.no_grad():
+            return np.concatenate([self.model(X).numpy() for X in dataloader])

--- a/examples/example_0n_synthetic_phantom_NNFBP.py
+++ b/examples/example_0n_synthetic_phantom_NNFBP.py
@@ -51,94 +51,104 @@ photon_flux_delta = 1e2
 photon_flux_noise = photon_flux_clean / photon_flux_delta
 
 num_angles_clean = int(180 * np.pi / 2)
-num_angles_noise = 60
+num_angles_noise = 180
 
 sino_clean, angles_rad_clean, expected_ph, _ = cct.utils_test.create_sino(
     ph, num_angles_clean, add_poisson=True, photon_flux=photon_flux_clean
 )
-sino_noise, angles_rad_noise, _, _ = cct.utils_test.create_sino(
+sino_noise_1, angles_rad_noise, _, _ = cct.utils_test.create_sino(
     ph, num_angles_noise, add_poisson=True, photon_flux=photon_flux_noise
 )
-sino_noise2, angles_rad_noise, _, _ = cct.utils_test.create_sino(
+sino_noise_2, angles_rad_noise2, _, _ = cct.utils_test.create_sino(
     ph, num_angles_noise, add_poisson=True, photon_flux=photon_flux_noise
 )
 
 expected_ph /= 1e4
 sino_clean /= 1e4
-sino_noise /= 1e4 / photon_flux_delta
-sino_noise2 /= 1e4 / photon_flux_delta
+sino_noise_1 /= 1e4 / photon_flux_delta
+sino_noise_2 /= 1e4 / photon_flux_delta
 
-print("High quality:")
 with cct.projectors.ProjectorUncorrected(vol_shape_xy, angles_rad_clean) as p:
     solver_fbp_sl = cct.solvers.FBP()
     vol_hq, _ = solver_fbp_sl(p, sino_clean)
+    print("High quality:")
     print("- Phantom power: %g, noise power: %g" % cct.utils_test.compute_error_power(expected_ph, vol_hq))
+
+with cct.projectors.ProjectorUncorrected(vol_shape_xy, angles_rad_noise2) as p:
+    solver_fbp_sl = cct.solvers.FBP()
+    vol_lq_1, _ = solver_fbp_sl(p, sino_noise_1)
+    vol_lq_2, _ = solver_fbp_sl(p, sino_noise_2)
+    print("Low quality:")
+    print("- Phantom power: %g, noise power: %g" % cct.utils_test.compute_error_power(expected_ph, vol_lq_1))
+
+    num_pix_trn = 2**13
+    num_pix_tst = 2**11
+    denoiser = cct.denoisers.Denoiser_NNFBP(
+        projector=p, num_pixels_trn=num_pix_trn, num_pixels_tst=num_pix_tst, num_fbps=4, hidden_layers=[4]
+    )
+    denoiser.fit(sino_noise_1, vol_hq, train_epochs=30)
+    # denoiser = cct.denoisers.Denoiser_N2F(
+    #     projector=p, num_pixels_trn=num_pix_trn, num_pixels_tst=num_pix_tst, num_fbps=4, hidden_layers=[4]
+    # )
+    # denoiser.fit(np.array([sino_noise_1, sino_noise_2]), np.array([vol_lq_2, vol_lq_1]), train_epochs=30)
+
+    # vol_den_1 = denoiser.predict(sino_noise_1)
+    vol_den_2 = denoiser.predict(sino_noise_2)
+    print("NNFBP quality:")
+    print("- Phantom power: %g, noise power: %g" % cct.utils_test.compute_error_power(expected_ph, vol_den_2))
+
+    filt_learned_f = denoiser.filters.filter_fourier
+    filt_learned_r = denoiser.filters.filter_real
+
+    sino_noise_mean = np.mean([sino_noise_1, sino_noise_2], axis=0)
+    solver_fbp_sl = cct.solvers.FBP(fbp_filter="hann")
+    vol_lq_m, _ = solver_fbp_sl(p, sino_noise_mean)
+    vol_den_m = denoiser.predict(sino_noise_mean)
+
+
+denoiser.filters.plot_filters()
+
+learned_rec_label = f"Learned ({denoiser.num_fbps}" + "".join([f"=>{l}" for l in denoiser.hidden_layers]) + "=>1)"
+
+# f, ax = plt.subplots(figsize=cm2inch([24, 10]))
+# ax.plot(np.squeeze((vol_hq * vol_mask)[..., 172]), label="High quality")
+# ax.plot(np.squeeze((vol_lq_2 * vol_mask)[..., 172]), label="Low quality")
+# ax.plot(np.squeeze((vol_den_2 * vol_mask)[..., 172]), label=learned_rec_label)
+# ax.plot(np.squeeze(expected_ph[..., 172]), label="Phantom")
+# ax.legend()
+# ax.grid()
+# f.tight_layout()
 
 vol_mask = cct.utils_proc.get_circular_mask(vol_hq.shape)
 
-with cct.projectors.ProjectorUncorrected(vol_shape_xy, angles_rad_noise) as p:
-    solver_fbp_sl = cct.solvers.FBP()
-    vol_lq, _ = solver_fbp_sl(p, sino_noise)
-    print("Training:")
-    den = cct.denoisers.Denoiser_NNFBP(projector=p, num_pixels_train=512, num_fbps=7, hidden_layers=[5, 3])
-    den.compute_filter(sino_noise, vol_hq)
-
-    # vol_den_hq = den.apply_filter(sino_noise)
-    vol_den_hq2 = den.apply_filter(sino_noise2)
-
-    filt_learned_f = den.filters.filter_fourier
-    filt_learned_r = den.filters.filter_real
-
-
-f, axes = plt.subplots(1, 2, figsize=cm2inch([24, 10]))
-for ii in range(den.filters.num_filters):
-    axes[0].plot(filt_learned_r[ii, ...], label=f"Learned-{ii}")
-axes[0].set_title("Real-space")
-axes[0].set_xlabel("Pixel")
-
-for ii in range(den.filters.num_filters):
-    axes[1].plot(filt_learned_f[ii, ...], label=f"Learned-{ii}")
-axes[1].set_title("Fourier-space")
-axes[1].set_xlabel("Frequency")
-
-axes[0].grid()
-axes[1].grid()
-axes[1].legend()
-f.tight_layout()
-
-learned_rec_label = f"Learned ({den.num_fbps}" + "".join([f"=>{l}" for l in den.hidden_layers]) + "=>1)"
-
-f, axes = plt.subplots(2, 2, sharex=True, sharey=True, figsize=cm2inch([24, 24]))
+f, axes = plt.subplots(2, 3, sharex=True, sharey=True, figsize=cm2inch([36, 24]))
 axes[0, 0].imshow(expected_ph)
 axes[0, 0].set_title("Phantom")
-axes[0, 1].imshow(vol_hq * vol_mask)
-axes[0, 1].set_title(f"High quality")
-axes[1, 0].imshow(vol_lq * vol_mask)
-axes[1, 0].set_title("Low quality")
-axes[1, 1].imshow(vol_den_hq2 * vol_mask)
+axes[1, 0].imshow(vol_hq * vol_mask)
+axes[1, 0].set_title(f"High quality (projs n.: {num_angles_clean} - max photons: {photon_flux_clean:.2e})")
+axes[0, 1].imshow(vol_lq_2 * vol_mask)
+axes[0, 1].set_title(f"Low quality (projs n.: {num_angles_noise} - max photons {photon_flux_noise:.2e})")
+axes[1, 1].imshow(vol_den_2 * vol_mask)
 axes[1, 1].set_title(learned_rec_label)
+axes[0, 2].imshow(vol_lq_m * vol_mask)
+axes[0, 2].set_title("Low quality - x2 dose")
+axes[1, 2].imshow(vol_den_m * vol_mask)
+axes[1, 2].set_title(learned_rec_label + " - x2 dose")
 f.tight_layout()
 
-
-f, ax = plt.subplots(figsize=cm2inch([24, 10]))
-ax.plot(np.squeeze((vol_hq * vol_mask)[..., 172]), label="High quality")
-ax.plot(np.squeeze((vol_lq * vol_mask)[..., 172]), label="Low quality")
-ax.plot(np.squeeze((vol_den_hq2 * vol_mask)[..., 172]), label=learned_rec_label)
-ax.plot(np.squeeze(expected_ph[..., 172]), label="Phantom")
-ax.legend()
-ax.grid()
-f.tight_layout()
-
-vols = [vol_hq * vol_mask, vol_lq * vol_mask, vol_den_hq2 * vol_mask]
-frcs = [None] * len(vols)
+vols = [vol_hq * vol_mask, vol_lq_2 * vol_mask, vol_den_2 * vol_mask, vol_lq_m * vol_mask, vol_den_m * vol_mask]
+frcs = [np.array([])] * len(vols)
 for ii, rec in enumerate(vols):
-    frcs[ii], T = cct.utils_proc.compute_frc(expected_ph, rec, snrt=0.4142, supersampling=2)
+    frcs[ii], T = cct.utils_proc.compute_frc(expected_ph, rec, snrt=0.4142)
 
-f, axs = plt.subplots(1, 1, sharex=True, sharey=True)
+f, axs = plt.subplots(1, 1, sharex=True, sharey=True, figsize=cm2inch((24, 12)))
 axs.plot(np.squeeze(frcs[0]), label="High quality")
 axs.plot(np.squeeze(frcs[1]), label="Low quality")
 axs.plot(np.squeeze(frcs[2]), label=learned_rec_label)
+axs.plot(np.squeeze(frcs[3]), label="Low quality - x2 dose")
+axs.plot(np.squeeze(frcs[4]), label=learned_rec_label + " - x2 dose")
 axs.plot(np.squeeze(T), label="T 1/2 bit")
+axs.set_ylim(0, None)
 axs.legend()
 axs.grid()
 f.tight_layout()

--- a/examples/example_0n_synthetic_phantom_NNFBP.py
+++ b/examples/example_0n_synthetic_phantom_NNFBP.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""
+This example shows the use and performance of the data dependent FBP filter, from:
+
+Pelt, D. M., & Batenburg, K. J. (2014). Improving filtered backprojection
+reconstruction by data-dependent filtering. Image Processing, IEEE
+Transactions on, 23(11), 4750-4762.
+
+@author: Nicola VIGANÒ, Computational Imaging group, CWI, The Netherlands,
+and ESRF - The European Synchrotron, Grenoble, France
+"""
+
+import numpy as np
+from numpy.typing import ArrayLike
+from typing import Tuple
+
+import matplotlib.pyplot as plt
+
+import corrct as cct
+import corrct.utils_test
+
+try:
+    import phantom
+except ImportError:
+    cct.utils_test.download_phantom()
+    import phantom
+
+
+def cm2inch(x: ArrayLike) -> Tuple[float, float]:
+    """Convert cm to inch.
+
+    Parameters
+    ----------
+    x : ArrayLike
+        Sizes in cm.
+
+    Returns
+    -------
+    Tuple[float, float]
+        Sizes in inch.
+    """
+    return tuple(np.array(x) / 2.54)
+
+
+vol_shape_xy = [256, 256]
+ph = np.squeeze(phantom.modified_shepp_logan([*vol_shape_xy, 3]).astype(np.float32))
+ph = ph[:, :, 1]
+
+sino_clean, angles_rad_clean, expected_ph, _ = cct.utils_test.create_sino(ph, 180, add_poisson=True, photon_flux=1e6)
+sino_noise, angles_rad_noise, _, _ = cct.utils_test.create_sino(ph, 60, add_poisson=True, photon_flux=1e4)
+sino_noise2, angles_rad_noise, _, _ = cct.utils_test.create_sino(ph, 60, add_poisson=True, photon_flux=1e4)
+
+expected_ph /= 1e4
+sino_clean /= 1e4
+sino_noise /= 1e2
+sino_noise2 /= 1e2
+
+print("High quality:")
+with cct.projectors.ProjectorUncorrected(vol_shape_xy, angles_rad_clean) as p:
+    solver_fbp_sl = cct.solvers.FBP()
+    vol_hq, _ = solver_fbp_sl(p, sino_clean)
+    print("- Phantom power: %g, noise power: %g" % cct.utils_test.compute_error_power(expected_ph, vol_hq))
+
+vol_mask = cct.utils_proc.get_circular_mask(vol_hq.shape)
+
+with cct.projectors.ProjectorUncorrected(vol_shape_xy, angles_rad_noise) as p:
+    solver_fbp_sl = cct.solvers.FBP()
+    vol_lq, _ = solver_fbp_sl(p, sino_noise)
+    print("Training:")
+    den = cct.denoisers.Denoiser_NNFBP(projector=p, num_pixels_train=256, num_fbps=7, hidden_layers=[3])
+    den.compute_filter(sino_noise, vol_hq)
+
+    # vol_den_hq = den.apply_filter(sino_noise)
+    vol_den_hq2 = den.apply_filter(sino_noise2)
+
+    filt_learned_f = den.filters.filter_fourier
+    filt_learned_r = den.filters.filter_real
+
+
+f, axes = plt.subplots(1, 2, figsize=cm2inch([24, 10]))
+for ii in range(den.filters.num_filters):
+    axes[0].plot(filt_learned_r[ii, ...], label=f"Learned-{ii}")
+axes[0].set_title("Real-space")
+axes[0].set_xlabel("Pixel")
+
+for ii in range(den.filters.num_filters):
+    axes[1].plot(filt_learned_f[ii, ...], label=f"Learned-{ii}")
+axes[1].set_title("Fourier-space")
+axes[1].set_xlabel("Frequency")
+
+axes[0].grid()
+axes[1].grid()
+axes[1].legend()
+f.tight_layout()
+
+learned_rec_label = f"Learned ({den.num_fbps}" + "".join([f"=>{l}" for l in den.hidden_layers]) + "=>1)"
+
+f, axes = plt.subplots(2, 2, sharex=True, sharey=True, figsize=cm2inch([24, 24]))
+axes[0, 0].imshow(expected_ph)
+axes[0, 0].set_title("Phantom")
+axes[0, 1].imshow(vol_hq * vol_mask)
+axes[0, 1].set_title(f"High quality")
+axes[1, 0].imshow(vol_lq * vol_mask)
+axes[1, 0].set_title("Low quality")
+axes[1, 1].imshow(vol_den_hq2 * vol_mask)
+axes[1, 1].set_title(learned_rec_label)
+f.tight_layout()
+
+
+f, ax = plt.subplots(figsize=cm2inch([24, 10]))
+ax.plot(np.squeeze((vol_hq * vol_mask)[..., 172]), label="High quality")
+ax.plot(np.squeeze((vol_lq * vol_mask)[..., 172]), label="Low quality")
+ax.plot(np.squeeze((vol_den_hq2 * vol_mask)[..., 172]), label=learned_rec_label)
+ax.plot(np.squeeze(expected_ph[..., 172]), label="Phantom")
+ax.legend()
+ax.grid()
+f.tight_layout()
+
+plt.show(block=False)


### PR DESCRIPTION
## Description

The NN-FBP method is a supervised machine learning method [1]. It uses a combination of a few FBP steps and a small neural network to obtain high quality reconstruction from low quality data. 
Once the neural network has been trained, it is characterized by high reconstruction speeds (as compared to iterative methods).
The FBP filters are learned during the training.
When used in a self-supervised context, the NN-FBP method is known as Noise2Filter (N2F) [2].

## TODO

- [X] Implement neural network supporting in the codebase.
- [X] Implement the NN-FBP / N2F method:
  - [X] Implement NN-FBP method (supervised).
  - [X] Implement N2F method (self-supervised).
- [ ] Optional: Add or update unittests.
- [ ] Add docstrings.
- [ ] Add example.

## Notes

This implementation currently uses PyTorch (@pytorch). It might be using scikit-learn (@scikit-learn) as a fall-back in the future.

## References
1. Pelt, D., & Batenburg, K. (2013). Fast tomographic reconstruction from limited data using artificial neural networks. Image Processing, IEEE Transactions on, 22(12), pp.5238-5251.
2. M. J Lagerwerf, A. A Hendriksen, J.-W. Buurlage, and K. Joost Batenburg, “Noise2Filter: fast, self-supervised learning and real-time reconstruction for 3D computed tomography,” Mach. Learn. Sci. Technol., vol. 2, no. 1, p. 015012, Mar. 2021, doi: 10.1088/2632-2153/abbd4d.