### PR TITLE
Add multi-channel regularization

### DIFF
--- a/corrct/regularizers.py
+++ b/corrct/regularizers.py
@@ -1061,7 +1061,7 @@ class Regularizer_vSVD(BaseRegularizer):
 
     def initialize_sigma_tau(self, primal: ArrayLike) -> Union[float, ArrayLike]:
         self.dtype = primal.dtype
-        self.op = operators.TransformSVD(primal.shape, axes_rows=self.axis_channels, axes_cols=self.axes)
+        self.op = operators.TransformSVD(primal.shape, axes_rows=self.axis_channels, axes_cols=self.axes, rescale=True)
 
         self.sigma = 1
         self.norm.assign_data(None, sigma=self.sigma)

--- a/corrct/regularizers.py
+++ b/corrct/regularizers.py
@@ -860,7 +860,7 @@ class Regularizer_VTV(Regularizer_Grad):
 
     def apply_proximal(self, dual: ArrayLike) -> None:
         # Following assignments will detach the local array from the original one
-        dual_tmp = dual
+        dual_tmp = dual.copy()
 
         dual_is_scalar = len(dual_tmp.shape) == (self.ndims + 1)
         if dual_is_scalar:
@@ -1000,7 +1000,7 @@ class Regularizer_vl1wl(Regularizer_l1swl):
         return tau
 
     def apply_proximal(self, dual: ArrayLike) -> None:
-        dual_tmp = dual
+        dual_tmp = dual.copy()
 
         if self.q_ref is not None:
             dual_tmp = np.concatenate((dual_tmp, self.q_ref), axis=1)

--- a/corrct/regularizers.py
+++ b/corrct/regularizers.py
@@ -795,12 +795,12 @@ class Regularizer_TNV(Regularizer_Grad):
 
     def __init__(
         self,
-        weight: Union[float, ArrayLike],
+        weight: Union[float, NDArray],
         ndims: int = 2,
         axes: Optional[Sequence[int]] = None,
         pad_mode: str = "edge",
         spectral_norm: DataFidelityBase = DataFidelity_l1(),
-        x_ref: Optional[ArrayLike] = None,
+        x_ref: Optional[NDArray] = None,
     ):
         super().__init__(weight=weight, ndims=ndims, axes=axes, pad_mode=pad_mode)
 
@@ -808,7 +808,7 @@ class Regularizer_TNV(Regularizer_Grad):
         self.norm = DataFidelity_ln(ln_axes=(1, 0), spectral_norm=spectral_norm)
         self.x_ref = x_ref
 
-    def initialize_sigma_tau(self, primal: ArrayLike) -> Union[float, ArrayLike]:
+    def initialize_sigma_tau(self, primal: NDArray) -> Union[float, NDArray]:
         tau = super().initialize_sigma_tau(primal)
 
         if self.x_ref is not None:
@@ -828,11 +828,11 @@ class Regularizer_VTV(Regularizer_Grad):
 
     def __init__(
         self,
-        weight: Union[float, ArrayLike],
+        weight: Union[float, NDArray],
         ndims: int = 2,
         pwise_der_norm: Union[int, float] = 2,
         pwise_chan_norm: Union[int, float] = np.inf,
-        x_ref: Optional[ArrayLike] = None,
+        x_ref: Optional[NDArray] = None,
     ):
         super().__init__(weight=weight, ndims=ndims)
 
@@ -858,7 +858,7 @@ class Regularizer_VTV(Regularizer_Grad):
             + f" Provided the following instead: derivatives={self.pwise_der_norm}, channel={self.pwise_chan_norm}"
         )
 
-    def apply_proximal(self, dual: ArrayLike) -> None:
+    def apply_proximal(self, dual: NDArray) -> None:
         # Following assignments will detach the local array from the original one
         dual_tmp = dual.copy()
 
@@ -909,7 +909,7 @@ class Regularizer_lnswl(Regularizer_l1swl):
 
     def __init__(
         self,
-        weight: Union[float, ArrayLike],
+        weight: Union[float, NDArray],
         wavelet: str,
         level: int,
         ndims: int = 2,
@@ -918,7 +918,7 @@ class Regularizer_lnswl(Regularizer_l1swl):
         normalized: bool = False,
         min_approx: bool = True,
         spectral_norm: DataFidelityBase = DataFidelity_l1(),
-        x_ref: Optional[ArrayLike] = None,
+        x_ref: Optional[NDArray] = None,
     ):
         super().__init__(
             weight,
@@ -934,7 +934,7 @@ class Regularizer_lnswl(Regularizer_l1swl):
         self.norm = DataFidelity_ln(ln_axes=(1, 0), spectral_norm=spectral_norm)
         self.x_ref = x_ref
 
-    def initialize_sigma_tau(self, primal: ArrayLike) -> Union[float, ArrayLike]:
+    def initialize_sigma_tau(self, primal: NDArray) -> Union[float, NDArray]:
         tau = super().initialize_sigma_tau(primal)
 
         if self.x_ref is not None:
@@ -951,7 +951,7 @@ class Regularizer_vl1wl(Regularizer_l1swl):
 
     def __init__(
         self,
-        weight: Union[float, ArrayLike],
+        weight: Union[float, NDArray],
         wavelet: str,
         level: int,
         ndims: int = 2,
@@ -961,7 +961,7 @@ class Regularizer_vl1wl(Regularizer_l1swl):
         min_approx: bool = True,
         pwise_lvl_norm: Union[int, float] = 1,
         pwise_chan_norm: Union[int, float] = np.Inf,
-        x_ref: ArrayLike = None,
+        x_ref: NDArray = None,
     ):
         super().__init__(
             weight,
@@ -991,7 +991,7 @@ class Regularizer_vl1wl(Regularizer_l1swl):
             + f" Provided the following instead: level={self.pwise_lvl_norm}, channel={self.pwise_chan_norm}"
         )
 
-    def initialize_sigma_tau(self, primal: ArrayLike) -> Union[float, ArrayLike]:
+    def initialize_sigma_tau(self, primal: NDArray) -> Union[float, NDArray]:
         tau = super().initialize_sigma_tau(primal)
 
         if self.x_ref is not None:
@@ -999,7 +999,7 @@ class Regularizer_vl1wl(Regularizer_l1swl):
 
         return tau
 
-    def apply_proximal(self, dual: ArrayLike) -> None:
+    def apply_proximal(self, dual: NDArray) -> None:
         dual_tmp = dual.copy()
 
         if self.q_ref is not None:
@@ -1042,7 +1042,7 @@ class Regularizer_vSVD(BaseRegularizer):
 
     def __init__(
         self,
-        weight: Union[float, ArrayLike],
+        weight: Union[float, NDArray],
         ndims: int = 2,
         axes: Optional[Sequence[int]] = None,
         axis_channels: Sequence[int] = (0,),
@@ -1059,7 +1059,7 @@ class Regularizer_vSVD(BaseRegularizer):
         self.axes = axes
         self.axis_channels = axis_channels
 
-    def initialize_sigma_tau(self, primal: ArrayLike) -> Union[float, ArrayLike]:
+    def initialize_sigma_tau(self, primal: NDArray) -> Union[float, NDArray]:
         self.dtype = primal.dtype
         self.op = operators.TransformSVD(primal.shape, axes_rows=self.axis_channels, axes_cols=self.axes, rescale=True)
 

--- a/corrct/solvers.py
+++ b/corrct/solvers.py
@@ -45,6 +45,9 @@ DataFidelity_l1b = data_terms.DataFidelity_l1b
 DataFidelity_Huber = data_terms.DataFidelity_Huber
 DataFidelity_KL = data_terms.DataFidelity_KL
 
+# Multi-channel
+DataFidelity_ln = data_terms.DataFidelity_ln
+
 
 # ---- Regularizers ----
 
@@ -68,6 +71,13 @@ Regularizer_Hub_dwl = regularizers.Regularizer_Hub_dwl
 Regularizer_l1med = regularizers.Regularizer_l1med
 Regularizer_l2med = regularizers.Regularizer_l2med
 Regularizer_fft = regularizers.Regularizer_fft
+
+# Multi-channel
+Regularizer_TNV = regularizers.Regularizer_TNV
+Regularizer_VTV = regularizers.Regularizer_VTV
+Regularizer_lnswl = regularizers.Regularizer_lnswl
+Regularizer_vl1wl = regularizers.Regularizer_vl1wl
+Regularizer_vSVD = regularizers.Regularizer_vSVD
 
 
 # ---- Constraints ----

--- a/examples/example_07_natural_image_multi-channel_regularization.py
+++ b/examples/example_07_natural_image_multi-channel_regularization.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Multi-channel TV regularization example.
+
+@author: Nicola VIGANÒ, Computational Imaging group, CWI, The Netherlands,
+and ESRF - The European Synchrotron, Grenoble, France
+"""
+
+import numpy as np
+import numpy.random
+
+import matplotlib.pyplot as plt
+
+import skimage as sk
+import skimage.data
+
+import time as tm
+
+import corrct as cct
+
+from numpy.typing import NDArray
+
+# Noise parameters
+gauss_stddev = None
+photon_num = 1e2
+
+# Reconstruction parameters
+lambda_tv_sc = 2.5e-3
+lambda_tv_mc = 1.7e-3
+iterations = 125
+
+
+c_s = tm.time()
+# Loading the image
+img_orig: NDArray = sk.data.astronaut()
+c_load = tm.time()
+print("Loaded img shape: %s, dtype: %s, in %g seconds." % (str(img_orig.shape), str(img_orig.dtype), (c_load - c_s)))
+
+# Transposing the image to have the multi-channel dimension as the slowest (axis=0 in Python)
+img_orig = img_orig.transpose([2, 0, 1])
+# Rescaling the image to be within the interval [0, 1]
+img_orig = img_orig.astype(np.float32) / 255
+
+img_noise = img_orig.copy()
+img_variance = np.zeros_like(img_orig)
+if photon_num is not None:
+    # This adds Poisson noise
+    img_noise = np.random.poisson(img_noise * photon_num) / photon_num
+    img_variance = img_variance + img_noise / photon_num
+if gauss_stddev is not None:
+    # This adds gaussian noise
+    img_noise += np.random.normal(size=img_orig.shape, scale=gauss_stddev)
+    img_variance = img_variance + gauss_stddev**2
+
+c_noise = tm.time()
+print("Added noise in %g seconds." % (c_noise - c_load))
+
+img_weights = cct.utils_proc.compute_variance_weigth(img_variance, normalized=True)
+
+# Data fitting term: weighted least-squares, based on the standard deviation of the noise. This is optional.
+data_term = cct.data_terms.DataFidelity_wl2(img_weights)
+
+# "Projection" operator. In this case, it's just a place holder, because we are denoising an image.
+A = cct.operators.TransformIdentity(img_orig.shape)
+
+c_stddev = tm.time()
+print("Prepared pixel confidence in %g seconds." % (c_stddev - c_noise))
+
+# Single channel TV regularizer
+reg_tv_s = cct.regularizers.Regularizer_TV2D(lambda_tv_sc)
+# Solver, which in this case is the PDHG method from Chambolle and Pock
+solver_tv_s = cct.solvers.PDHG(data_term=data_term, verbose=True, regularizer=reg_tv_s)
+# We now run the solver on the noisy image
+(img_tvs, _) = solver_tv_s(A, img_noise, x0=img_noise, iterations=iterations, lower_limit=0.0)
+
+# Multi channel TV regularizer - aka TNV
+reg_tv_m = cct.regularizers.Regularizer_TNV(lambda_tv_mc)
+# Solver, which in this case is the PDHG method from Chambolle and Pock
+solver_tv_m = cct.solvers.PDHG(data_term=data_term, verbose=True, regularizer=reg_tv_m)
+# We now run the solver on the noisy image
+(img_tvm, _) = solver_tv_m(A, img_noise, x0=img_noise, iterations=iterations, lower_limit=0.0)
+
+# Plotting the result
+f, axs = plt.subplots(2, 2, sharex=True, sharey=True, squeeze=False, figsize=[7, 7])
+axs[0, 0].imshow(img_orig.transpose([1, 2, 0]))
+axs[0, 0].set_title("Original")
+axs[1, 0].imshow(img_noise.clip(0, 1).transpose([1, 2, 0]))
+axs[1, 0].set_title("Noise")
+
+axs[0, 1].imshow(img_tvs.clip(0, 1).transpose([1, 2, 0]))
+axs[0, 1].set_title("Single-channel TV, weight: %f" % (lambda_tv_sc))
+axs[1, 1].imshow(img_tvm.clip(0, 1).transpose([1, 2, 0]))
+axs[1, 1].set_title("Multi-channel TV, weight: %f" % (lambda_tv_mc))
+
+f.tight_layout()
+plt.show(block=False)

--- a/examples/example_08_synthetic_phantom_multi-channel_regularization.py
+++ b/examples/example_08_synthetic_phantom_multi-channel_regularization.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Multi-channel tomography TV regularization example.
+
+@author: Nicola VIGANÒ, Computational Imaging group, CWI, The Netherlands,
+and ESRF - The European Synchrotron, Grenoble, France
+"""
+
+import numpy as np
+import numpy.random
+
+import matplotlib.pyplot as plt
+
+import corrct as cct
+import corrct.utils_test as cct_test
+
+from typing import Tuple
+from numpy.typing import ArrayLike
+
+try:
+    import phantom
+except ImportError:
+    cct_test.download_phantom()
+    import phantom
+
+
+def cm2inch(x: ArrayLike) -> Tuple[float, float]:
+    """Convert cm to inch.
+
+    Parameters
+    ----------
+    x : ArrayLike
+        Sizes in cm.
+
+    Returns
+    -------
+    Tuple[float, float]
+        Sizes in inch.
+    """
+    return tuple(np.array(x) / 2.54)
+
+
+data_type = np.float32
+
+# Create the phantom shape
+ph_or = np.squeeze(phantom.modified_shepp_logan([256, 256, 3]).astype(data_type))
+ph_or = ph_or[:, :, 1]
+
+dwell_time_s = 1e-2
+bckgnd_avg = 1e-4  # Background concentrations averages
+beam_energy_keV = 20.0
+
+# Simulate the XRF-CT acquisition data (sinogram)
+(phantoms, vol_att_in, vols_att_out) = cct_test.phantom_assign_concentration_multi(ph_or, in_energy_keV=beam_energy_keV)
+
+num_vols = len(phantoms) + 1
+sinogram = [np.array([])] * num_vols
+expected_ph = [np.array([])] * num_vols
+background_avg = np.zeros((num_vols,))
+
+# Compute Fluorescence and Compton projections
+for ii, (ph, vol_att_out) in enumerate(zip(phantoms, vols_att_out)):
+    (sinogram[ii], angles, expected_ph[ii], background_avg[ii]) = cct_test.create_sino(
+        ph, 30, add_poisson=True, dwell_time_s=dwell_time_s, background_avg=bckgnd_avg
+    )
+
+# Compute attenuation projections
+(sinogram_t, flat, angles, expected_ph[-1]) = cct_test.create_sino_transmission(
+    vol_att_in, 30, add_poisson=True, dwell_time_s=dwell_time_s
+)
+sinogram[-1] = cct.utils_proc.apply_minus_log(cct.utils_proc.apply_flat_field(sinogram_t, flat))
+
+sinogram = np.array(sinogram)
+expected_ph = np.array(expected_ph)
+
+iterations = 200
+lower_limit = 0.0
+lambda_tv = 10.0
+vol_mask = cct.utils_proc.get_circular_mask(ph_or.shape)
+
+# Subtract background from sinogram
+sino_substr = sinogram - background_avg[:, None, None]
+
+# f, axs = plt.subplots(sino_substr.shape[0], 1, sharex=True, sharey=True)
+# for ax, sino in zip(axs, sino_substr):
+#     ax.imshow(sino)
+# f.tight_layout()
+# plt.show(block=False)
+
+sino_substr = np.fmax(sino_substr, 0)
+
+norm_signals = np.mean(sino_substr, axis=(-2, -1), keepdims=True)
+renorm_transm = norm_signals[-1] / np.mean(norm_signals[:2])
+
+sino_substr[-1] /= renorm_transm
+
+sino_variances_poisson = cct.utils_proc.compute_variance_poisson(sinogram[:-1, ...])
+sino_variances_gauss = cct.utils_proc.compute_variance_transmission(sinogram_t, flat)
+
+sino_weights_poisson = np.stack(
+    [cct.utils_proc.compute_variance_weigth(v, normalized=True, semilog=True) for v in sino_variances_poisson], axis=0
+)
+sino_weights_transmission = cct.utils_proc.compute_variance_weigth(sino_variances_gauss[None, ...], normalized=True)
+sino_weights = np.concatenate((sino_weights_poisson, sino_weights_transmission), axis=0)
+
+# f, axs = plt.subplots(sino_weights.shape[0], 1, sharex=True, sharey=True)
+# for ax, sino in zip(axs, sino_weights):
+#     ax.imshow(sino)
+# f.tight_layout()
+# plt.show(block=False)
+
+# Data fitting term: weighted least-squares, based on the standard deviation of the noise.
+data_term_lsw = cct.data_terms.DataFidelity_wl2(sino_weights)
+
+with cct.projectors.ProjectorUncorrected([*ph_or.shape, num_vols], angles) as A:
+    # Weighted least squares
+    solver_wls = cct.solvers.PDHG(verbose=True, data_term=data_term_lsw)
+    rec_wls, _ = solver_wls(A, sino_substr, iterations, x_mask=vol_mask, lower_limit=lower_limit)
+
+    # Single channel TV regularizer
+    reg_tv = cct.regularizers.Regularizer_TV2D(lambda_tv)
+    # Solver, which in this case is the PDHG method from Chambolle and Pock
+    solver_tv = cct.solvers.PDHG(data_term=data_term_lsw, verbose=True, regularizer=reg_tv)
+    # We now run the solver on the noisy image
+    (rec_tvs, _) = solver_tv(A, sino_substr, iterations, x_mask=vol_mask, lower_limit=lower_limit)
+
+    # Multi channel TV regularizer - aka TNV
+    reg_vtv = cct.regularizers.Regularizer_TNV(lambda_tv)
+    # Solver, which in this case is the PDHG method from Chambolle and Pock
+    solver_tnv = cct.solvers.PDHG(data_term=data_term_lsw, verbose=True, regularizer=reg_vtv)
+    # We now run the solver on the noisy image
+    (rec_tvm, _) = solver_tnv(A, sino_substr, iterations, x_mask=vol_mask, lower_limit=lower_limit)
+
+rec_wls[-1] *= renorm_transm
+rec_tvs[-1] *= renorm_transm
+rec_tvm[-1] *= renorm_transm
+
+f, axs = plt.subplots(3, num_vols + 1, sharex=True, sharey=True, figsize=cm2inch([27, 20]))
+for ax, ph, vol_wls, vol_tvs, vol_tvm in zip(axs, expected_ph, rec_wls, rec_tvs, rec_tvm):
+    ax[0].imshow(ph)
+    ax[1].imshow(vol_wls)
+    ax[2].imshow(vol_tvs)
+    ax[3].imshow(vol_tvm)
+axs[0, 0].set_title("Phantom")
+axs[0, 1].set_title(solver_wls.info())
+axs[0, 2].set_title(solver_tv.info())
+axs[0, 3].set_title(solver_tnv.info())
+axs[0, 0].set_ylabel("Ca")
+axs[1, 0].set_ylabel("Fe")
+axs[2, 0].set_ylabel("Attenuation")
+
+f.tight_layout()
+plt.show(block=False)

--- a/examples/example_08_synthetic_phantom_multi-channel_regularization.py
+++ b/examples/example_08_synthetic_phantom_multi-channel_regularization.py
@@ -149,6 +149,21 @@ axs[0, 3].set_title(solver_tnv.info())
 axs[0, 0].set_ylabel("Ca")
 axs[1, 0].set_ylabel("Fe")
 axs[2, 0].set_ylabel("Attenuation")
-
 f.tight_layout()
+
+# Comparing FRCs for each reconstruction
+frcs = [np.array([])] * 3
+for ii, rec in enumerate([rec_wls[0], rec_tvs[0], rec_tvm[0]]):
+    frcs[ii], T = cct.utils_proc.compute_frc(expected_ph[0], rec, snrt=0.4142)
+
+f, ax = plt.subplots(1, 1, sharex=True, sharey=True)
+ax.plot(np.squeeze(frcs[0]), label=solver_wls.info().upper())
+ax.plot(np.squeeze(frcs[1]), label=solver_tv.info().upper())
+ax.plot(np.squeeze(frcs[2]), label=solver_tnv.info().upper())
+ax.plot(np.squeeze(T), label="T 1/2 bit")
+ax.legend()
+ax.grid()
+ax.set_title("FRCs for Ca-Ka")
+f.tight_layout()
+
 plt.show(block=False)


### PR DESCRIPTION
## Description

Multi-channel regularizations allow to exploit the information from correlated channels in order to provide higher quality reconstructions. Here we add basic multi-channel regularization classes, including TNV (Total Nuclear Variation) [1].
Moreover, we add vectorial / collaborative TV implementations [2], and collaborative wavelet regularization.

## TODO

- [x] Implement multi-channel regularizations
  - [x] SVD Transform
  - [x] Data-fidelity term for the ln norm
  - [x] gradient methods (TNV, VTV)
  - [x] wavelet method (both spectral and vector)
- [x] Add docstrings
- [x] Create examples

## Notes

References to TNV:
[1] D. S. Rigie and P. J. La Rivière, “Joint reconstruction of multi-channel, spectral CT data via constrained total nuclear variation minimization.,” Phys. Med. Biol., vol. 60, no. 5, pp. 1741–62, 2015, doi: 10.1088/0031-9155/60/5/1741.
[2] J. Duran, M. Moeller, C. Sbert, and D. Cremers, “Collaborative Total Variation: A General Framework for Vectorial TV Models,” SIAM J. Imaging Sci., vol. 9, no. 1, pp. 116–151, Jan. 2016.
