### PR TITLE
Update packaging in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 """The setup script."""
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
-if __name__ == '__main__':
-    setup()
+if __name__ == "__main__":
+    setup(packages=find_packages("./corrct"), package_dir={"": "./corrct"})

--- a/setup.py
+++ b/setup.py
@@ -6,4 +6,4 @@
 from setuptools import find_packages, setup
 
 if __name__ == "__main__":
-    setup(packages=find_packages("./corrct"), package_dir={"": "./corrct"})
+    setup(packages=find_packages(include=["corrct", "corrct.*"]))


### PR DESCRIPTION
## Description

I discovered last week that the latest version of corrct available on PyPI will raise a packaging error `ModuleNotFoundError: No module named 'corrct.processing'` when imported. This was also the case when installing from a cloned version of the  repository.

This PR updates `setup.py` to make sure subpackages are found during setup.

## TODO

- [x] Implement new feature.
- [-] Add or update unittests.
- [-] Add or update docstrings.

