### PR TITLE
Add support for primal domain regularization

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This package provides the following functionality:
     * Various data fitting terms, including **Gaussian and Poisson noise** modelling.
     * Various optional regularization terms, including: **TV-min**, l1-min, laplacian, and **wavelet** l1-min.
     * Multi-channel (collaborative) regularization terms, like: **TNV** (Total Nuclear Variation).
+  - Fast Iterative Shrinkage-Thresholding Algorithm (FISTA).
   - Filtered Back-Projection (**FBP**), and its data-dependent filter learning variant
 (**[PyMR-FBP](https://github.com/dmpelt/pymrfbp)**).
 * Two projector backends, based on: [astra-toolbox](https://github.com/astra-toolbox/astra-toolbox) and

--- a/doc_sources/tutorial.md
+++ b/doc_sources/tutorial.md
@@ -124,12 +124,15 @@ filter can be selected, by passing the `fbp_filter` parameter at initialization:
 solver_fbp = cct.solvers.FBP(fbp_filter="shepp-logan")
 ```
 
-#### SIRT, PDHG, and MLEM
+#### SIRT, PDHG, MLEM, and FISTA
 
-The SIRT and PDHG algorithms, are algebraic (iterative) methods. They both
+The SIRT, PDHG and FISTA algorithms, are algebraic (iterative) methods. They all
 support regularization, and box constraints on the solution. The PDHG also
-supports various data fidelity terms.
-The MLEM algorithm is also an iterative algorithm to find the maximum likelihood estimation of the reconstructed signal. The MLEM does not currently support any regularization.
+supports various data fidelity terms. FISTA only supports regularizations that
+form a tight Parseval frame (like certain wavelet transforms).
+The MLEM algorithm is also an iterative algorithm to find the maximum likelihood
+estimation of the reconstructed signal. The MLEM does not currently support any
+regularization.
 
 The interface of the iterative methods is the same as for the FBP, with the only
 difference of requiring an iterations count:
@@ -146,7 +149,7 @@ with cct.projectors.ProjectorUncorrected(vol_shape_xy, angles_rad) as p:
     vol, _ = solver_sirt(p, sino, iterations=100)
 ```
 
-It is possible to specify an intial solution or box limits on the solutions like
+It is possible to specify an initial solution or box limits on the solutions like
 the following:
 ```python
 x0 = np.ones(vol_shape_xy)  # Initial solution

--- a/examples/example_09_synthetic_phantom_PDHG_vs_FISTA.py
+++ b/examples/example_09_synthetic_phantom_PDHG_vs_FISTA.py
@@ -1,0 +1,129 @@
+"""
+This example compares the fista solver against SIRT and weighted least-squares
+reconstructions (implemented with the PDHG algorithm) of the Shepp-Logan phantom.
+
+@author: Jérome Lesaint, ESRF - The European Synchrotron, Grenoble, France
+"""
+
+from collections.abc import Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+import corrct as cct
+
+try:
+    import phantom
+except ImportError:
+    cct.testing.download_phantom()
+    import phantom
+
+
+def cm2inch(x: Sequence[float]) -> tuple[float, float]:
+    """Convert cm to inch.
+
+    Parameters
+    ----------
+    x : ArrayLike
+        Sizes in cm.
+
+    Returns
+    -------
+    tuple[float, float]
+        Sizes in inch.
+    """
+    return tuple(np.array(x) / 2.54)
+
+
+vol_shape = [256, 256, 3]
+data_type = np.float32
+
+ph_or = np.squeeze(phantom.modified_shepp_logan(vol_shape).astype(data_type))
+ph_or = ph_or[:, :, 1]
+
+ph, vol_att_in, vol_att_out = cct.testing.phantom_assign_concentration(ph_or)
+# Create sino with no background noise.
+sino, angles, expected_ph, background_avg = cct.testing.create_sino(
+    ph, 30, psf=None, add_poisson=True, dwell_time_s=1e-1, background_avg=1e-5, background_std=1e-6, dtype=np.float32
+)
+
+num_iterations = 100
+lower_limit = 0
+vol_mask = cct.processing.circular_mask(ph_or.shape)
+
+sino_variance = cct.processing.compute_variance_poisson(sino)
+sino_weights = cct.processing.compute_variance_weight(sino_variance, normalized=True)
+
+data_term_ls = cct.data_terms.DataFidelity_l2(background=background_avg)
+data_term_lsw = cct.data_terms.DataFidelity_wl2(sino_weights, background=background_avg)
+data_term_kl = cct.data_terms.DataFidelity_KL(background=background_avg)
+
+with cct.projectors.ProjectorUncorrected(ph.shape, angles) as A:
+    reg = cct.regularizers.Regularizer_l1dwl(1e-1, "Haar", 3)
+    solver_pdhg = cct.solvers.PDHG(verbose=True, data_term=data_term_kl, regularizer=reg)
+    rec_pdhg, _ = solver_pdhg(A, sino, num_iterations, x_mask=vol_mask)
+
+    solver_sirt = cct.solvers.SIRT(verbose=True, data_term=data_term_lsw)
+    rec_sirt, _ = solver_sirt(A, sino, num_iterations, x_mask=vol_mask)
+
+    reg = cct.regularizers.Regularizer_l1dwl(1e-2, "Haar", 3)
+    solver_fista = cct.solvers.FISTA(verbose=True, data_term=data_term_lsw, regularizer=reg)
+    rec_fista, _ = solver_fista(A, sino, num_iterations, x_mask=vol_mask)
+
+
+vminmax = dict(vmin=expected_ph.min(), vmax=expected_ph.max())
+
+# Reconstructions
+fig = plt.figure(figsize=cm2inch([36, 24]))
+gs = fig.add_gridspec(8, 3)
+ax_ph = fig.add_subplot(gs[:4, 0])
+im_ph = ax_ph.imshow(expected_ph, **vminmax)
+ax_ph.set_title("Phantom")
+fig.colorbar(im_ph, ax=ax_ph)
+
+ax_sino_clean = fig.add_subplot(gs[4, 0])
+with cct.projectors.ProjectorUncorrected(ph_or.shape, angles) as p:
+    sino_clean = p.fp(expected_ph)
+im_sino_clean = ax_sino_clean.imshow(sino_clean)
+ax_sino_clean.set_title("Clean sinogram")
+
+ax_sino_noise = fig.add_subplot(gs[5, 0])
+im_sino_noise = ax_sino_noise.imshow(sino - background_avg)
+ax_sino_noise.set_title("Noisy sinogram")
+
+ax_sino_lines = fig.add_subplot(gs[6:, 0])
+im_sino_lines = ax_sino_lines.plot(sino[9, :] - background_avg, label="Noisy")
+im_sino_lines = ax_sino_lines.plot(sino_clean[9, :], label="Clean")
+ax_sino_lines.set_title("Sinograms - angle: 10")
+ax_sino_lines.legend()
+ax_sino_lines.grid()
+
+ax_wls_l = fig.add_subplot(gs[:4, 1], sharex=ax_ph, sharey=ax_ph)
+im_wls_l = ax_wls_l.imshow(np.squeeze(rec_pdhg), **vminmax)
+ax_wls_l.set_title(solver_pdhg.info().upper())
+fig.colorbar(im_wls_l, ax=ax_wls_l)
+
+ax_sirt = fig.add_subplot(gs[4:, 1], sharex=ax_ph, sharey=ax_ph)
+im_sirt = ax_sirt.imshow(np.squeeze(rec_sirt), **vminmax)
+ax_sirt.set_title(solver_sirt.info().upper())
+fig.colorbar(im_sirt, ax=ax_sirt)
+
+ax_fista = fig.add_subplot(gs[:4, 2], sharex=ax_ph, sharey=ax_ph)
+im_fista = ax_fista.imshow(np.squeeze(rec_fista), **vminmax)
+ax_fista.set_title(solver_fista.info().upper())
+fig.colorbar(im_fista, ax=ax_fista)
+
+axs = fig.add_subplot(gs[4:, 2])
+axs.plot(np.squeeze(expected_ph[..., 172]), label="Phantom")
+axs.plot(np.squeeze(rec_pdhg[..., 172]), label=solver_pdhg.info().upper())
+axs.plot(np.squeeze(rec_sirt[..., 172]), label=solver_sirt.info().upper())
+axs.plot(np.squeeze(rec_fista[..., 172]), label=solver_fista.info().upper())
+axs.grid()
+axs.legend()
+fig.tight_layout()
+
+# Comparing FRCs for each reconstruction
+labels = [solver_pdhg.info().upper(), solver_sirt.info().upper(), solver_fista.info().upper()]
+vols = [rec_pdhg, rec_sirt, rec_fista]
+cct.processing.post.plot_frcs([(expected_ph, rec) for rec in vols], labels=labels, snrt=0.4142)
+
+plt.show(block=False)

--- a/src/corrct/data_terms.py
+++ b/src/corrct/data_terms.py
@@ -234,7 +234,7 @@ class DataFidelityBase(ABC):
             dual += (proj_primal + self.background) * self.sigma
 
     @abstractmethod
-    def apply_proximal(self, dual: NDArrayFloat) -> None:
+    def apply_proximal_dual(self, dual: NDArrayFloat) -> None:
         """Apply the proximal in the dual domain.
 
         Parameters
@@ -283,7 +283,7 @@ class DataFidelity_l2(DataFidelityBase):
     def compute_residual_norm(self, dual: NDArrayFloat) -> float:
         return float(np.linalg.norm(dual.flatten(), ord=2) ** 2)
 
-    def apply_proximal(self, dual: NDArrayFloat) -> None:
+    def apply_proximal_dual(self, dual: NDArrayFloat) -> None:
         if self.data is not None and self.sigma_data is not None:
             dual -= self.sigma_data
         dual *= self.sigma1
@@ -364,7 +364,7 @@ class DataFidelity_l2b(DataFidelity_l2):
         _soft_threshold(residual, self.sigma_sqrt_error)
         return residual
 
-    def apply_proximal(self, dual: NDArrayFloat) -> None:
+    def apply_proximal_dual(self, dual: NDArrayFloat) -> None:
         if self.data is not None and self.sigma_data is not None:
             dual -= self.sigma_data
         _soft_threshold(dual, self.sigma_sqrt_error)
@@ -401,7 +401,7 @@ class DataFidelity_Huber(DataFidelityBase):
         l1_points = 1 - l2_points
         return np.linalg.norm(dual[l2_points].flatten(), ord=2) ** 2 + np.linalg.norm(dual[l1_points].flatten(), ord=1)
 
-    def apply_proximal(self, dual):
+    def apply_proximal_dual(self, dual):
         if self.data is not None and self.sigma_data is not None:
             dual -= self.sigma_data
 
@@ -437,7 +437,7 @@ class DataFidelity_l1(DataFidelityBase):
     def _apply_threshold(self, dual):
         pass
 
-    def apply_proximal(self, dual, weight=1.0):
+    def apply_proximal_dual(self, dual, weight=1.0):
         if self.data is not None:
             dual -= self.sigma_data
         self._apply_threshold(dual)
@@ -505,7 +505,7 @@ class DataFidelity_KL(DataFidelityBase):
         else:
             return 4 * self.sigma * np.fmax(self.data, 0.0)
 
-    def apply_proximal(self, dual):
+    def apply_proximal_dual(self, dual):
         if self.sigma_data is not None:
             dual[:] = (1 + dual[:] - np.sqrt((dual[:] - 1) ** 2 + self.sigma_data[:])) / 2
         else:
@@ -517,7 +517,7 @@ class DataFidelity_KL(DataFidelityBase):
         # we take the Moreau envelope here, and apply the proximal to it
         residual = np.fmax(proj_primal, eps) * self.sigma
 
-        self.apply_proximal(residual)
+        self.apply_proximal_dual(residual)
 
         if mask is not None:
             residual *= mask
@@ -553,7 +553,7 @@ class DataFidelity_ln(DataFidelityBase):
         self.spectral_norm = spectral_norm
         self.use_fallback = False
 
-    def apply_proximal(self, dual):
+    def apply_proximal_dual(self, dual):
         dual_tmp = dual.copy()
 
         if self.sigma_data is not None:
@@ -569,7 +569,7 @@ class DataFidelity_ln(DataFidelityBase):
 
             U, s_p, Vt = np.linalg.svd(dual_tmp, full_matrices=False)
 
-            self.spectral_norm.apply_proximal(s_p)
+            self.spectral_norm.apply_proximal_dual(s_p)
 
             dual_tmp = np.matmul(U, s_p[..., None] * Vt)
             dual_tmp = np.transpose(dual_tmp, np.argsort(t_range))
@@ -577,7 +577,7 @@ class DataFidelity_ln(DataFidelityBase):
             op_svd = operators.TransformSVD(dual_tmp.shape, axes_rows=self.ln_axes[0], axes_cols=self.ln_axes[1])
             s_p = op_svd(dual_tmp)
 
-            self.spectral_norm.apply_proximal(s_p)
+            self.spectral_norm.apply_proximal_dual(s_p)
 
             dual_tmp = op_svd.T(s_p)
 

--- a/src/corrct/data_terms.py
+++ b/src/corrct/data_terms.py
@@ -475,22 +475,24 @@ class DataFidelity_Huber(DataFidelityBase):
 
     one_sigma_error: float | NDArrayFloat
 
-    def __init__(self, local_error, background=None, l2_axis=None):
+    def __init__(
+        self, local_error: float | NDArrayFloat, background: float | NDArrayFloat | None = None, l2_axis: int | None = None
+    ):
         super().__init__(background=background)
         self.local_error = local_error
         self.l2_axis = l2_axis
         self.one_sigma_error = 1.0
 
-    def assign_data(self, data, sigma=1.0):
+    def assign_data(self, data: NDArrayFloat, sigma: float | NDArrayFloat = 1.0):
         self.one_sigma_error = 1.0 / (1.0 + sigma * self.local_error)
         super().assign_data(data=data, sigma=sigma)
 
-    def compute_residual_norm(self, dual):
+    def compute_residual_norm(self, dual: NDArrayFloat) -> float:
         l2_points = dual <= self.local_error
         l1_points = 1 - l2_points
-        return np.linalg.norm(dual[l2_points].flatten(), ord=2) ** 2 + np.linalg.norm(dual[l1_points].flatten(), ord=1)
+        return float(np.linalg.norm(dual[l2_points].flatten(), ord=2) ** 2 + np.linalg.norm(dual[l1_points].flatten(), ord=1))
 
-    def apply_proximal_dual(self, dual):
+    def apply_proximal_dual(self, dual: NDArrayFloat) -> None:
         if self.data is not None and self.sigma_data is not None:
             dual -= self.sigma_data
 
@@ -522,10 +524,12 @@ class DataFidelity_Huber(DataFidelityBase):
             "Use a gradient step in the solver, or switch to PDHG for this data term."
         )
 
-    def compute_primal_dual_gap(self, proj_primal, dual, mask=None):
+    def compute_primal_dual_gap(
+        self, proj_primal: NDArrayFloat, dual: NDArrayFloat, mask: NDArrayFloat | None = None
+    ) -> float:
         if self.background is not None:
             proj_primal = proj_primal + self.background
-        return (
+        return float(
             np.linalg.norm(self.compute_residual(proj_primal, mask), ord=2)
             + self.compute_data_dual_dot(dual)
             + self.local_error * np.linalg.norm(dual, ord=2)
@@ -540,14 +544,14 @@ class DataFidelity_l1(DataFidelityBase):
     def __init__(self, background=None):
         super().__init__(background=background)
 
-    def _get_inner_norm(self, dual):
+    def _get_inner_norm(self, dual: NDArrayFloat) -> NDArrayFloat:
         return np.abs(dual)
 
-    def _apply_threshold(self, dual):
+    def _apply_threshold(self, dual: NDArrayFloat):
         pass
 
-    def apply_proximal_dual(self, dual, weight=1.0):
-        if self.data is not None:
+    def apply_proximal_dual(self, dual: NDArrayFloat, weight: float | NDArrayFloat = 1.0):
+        if self.data is not None and self.sigma_data is not None:
             dual -= self.sigma_data
         self._apply_threshold(dual)
         dual_inner_norm = self._get_inner_norm(dual)
@@ -577,20 +581,22 @@ class DataFidelity_l1(DataFidelityBase):
         if self.data is not None:
             primal += self.data
 
-    def compute_residual_norm(self, dual):
+    def compute_residual_norm(self, dual: NDArrayFloat) -> float:
         dual = dual.copy()
         self._apply_threshold(dual)
         dual_inner_norm = self._get_inner_norm(dual)
-        return np.linalg.norm(dual_inner_norm, ord=1)
+        return float(np.linalg.norm(dual_inner_norm, ord=1))
 
-    def compute_primal_dual_gap(self, proj_primal, dual, mask=None):
+    def compute_primal_dual_gap(
+        self, proj_primal: NDArrayFloat, dual: NDArrayFloat, mask: NDArrayFloat | None = None
+    ) -> float:
         if self.background is not None:
             proj_primal = proj_primal + self.background
 
         residual = self.compute_residual(proj_primal, mask)
         self._apply_threshold(residual)
         residual_inner_norm = self._get_inner_norm(residual)
-        return np.linalg.norm(residual_inner_norm, ord=1) + self.compute_data_dual_dot(dual)
+        return float(np.linalg.norm(residual_inner_norm, ord=1) + self.compute_data_dual_dot(dual))
 
 
 class DataFidelity_l12(DataFidelity_l1):
@@ -598,11 +604,11 @@ class DataFidelity_l12(DataFidelity_l1):
 
     __data_fidelity_name__ = "l12"
 
-    def __init__(self, background=None, l2_axis=0):
+    def __init__(self, background: float | NDArrayFloat | None = None, l2_axis: int = 0):
         super().__init__(background=background)
         self.l2_axis = l2_axis
 
-    def _get_inner_norm(self, dual):
+    def _get_inner_norm(self, dual: NDArrayFloat) -> NDArrayFloat:
         return np.linalg.norm(dual, ord=2, axis=self.l2_axis, keepdims=True)
 
     def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
@@ -630,16 +636,16 @@ class DataFidelity_l1b(DataFidelity_l1):
 
     sigma_error: float | NDArrayFloat
 
-    def __init__(self, local_error, background=None):
+    def __init__(self, local_error: float | NDArrayFloat, background: float | NDArrayFloat | None = None) -> None:
         super().__init__(background=background)
         self.local_error = local_error
         self.sigma_error = 1.0 * self.local_error
 
-    def assign_data(self, data, sigma=1.0):
+    def assign_data(self, data: NDArrayFloat, sigma: float | NDArrayFloat = 1.0) -> None:
         self.sigma_error = sigma * self.local_error
         super().assign_data(data=data, sigma=sigma)
 
-    def _apply_threshold(self, dual):
+    def _apply_threshold(self, dual: NDArrayFloat) -> None:
         _soft_threshold(dual, self.local_error)
 
     def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
@@ -683,7 +689,7 @@ class DataFidelity_KL(DataFidelityBase):
         else:
             return 4 * self.sigma * np.fmax(self.data, 0.0)
 
-    def apply_proximal_dual(self, dual):
+    def apply_proximal_dual(self, dual: NDArrayFloat):
         if self.sigma_data is not None:
             dual[:] = (1 + dual[:] - np.sqrt((dual[:] - 1) ** 2 + self.sigma_data[:])) / 2
         else:
@@ -736,10 +742,10 @@ class DataFidelity_KL(DataFidelityBase):
             residual *= mask
         return -residual
 
-    def compute_residual_norm(self, dual):
-        return np.linalg.norm(dual.flatten(), ord=1)
+    def compute_residual_norm(self, dual: NDArrayFloat) -> float:
+        return float(np.linalg.norm(dual.flatten(), ord=1))
 
-    def compute_primal_dual_gap(self, proj_primal, dual, mask=None):
+    def compute_primal_dual_gap(self, proj_primal: NDArrayFloat, dual: NDArrayFloat, mask: NDArrayFloat | None = None):
         if self.background is not None:
             proj_primal = proj_primal + self.background
 
@@ -760,13 +766,20 @@ class DataFidelity_ln(DataFidelityBase):
 
     __data_fidelity_name__ = "ln"
 
-    def __init__(self, background=None, ln_axes: Sequence[int] = (1, -1), spectral_norm: DataFidelityBase = DataFidelity_l1()):
+    ln_axes: Sequence[int]
+
+    def __init__(
+        self,
+        background: float | NDArrayFloat | None = None,
+        ln_axes: Sequence[int] = (1, -1),
+        spectral_norm: DataFidelityBase = DataFidelity_l1(),
+    ):
         super().__init__(background=background)
         self.ln_axes = ln_axes
         self.spectral_norm = spectral_norm
         self.use_fallback = False
 
-    def apply_proximal_dual(self, dual):
+    def apply_proximal_dual(self, dual: NDArrayFloat) -> None:
         dual_tmp = dual.copy()
 
         if self.sigma_data is not None:
@@ -819,12 +832,12 @@ class DataFidelity_ln(DataFidelityBase):
             "It cannot be applied generically in the primal domain. Use PDHG instead."
         )
 
-    def compute_residual_norm(self, dual):
+    def compute_residual_norm(self, dual: NDArrayFloat) -> float:
         op_svd = operators.TransformSVD(dual.shape, axes_rows=self.ln_axes[0], axes_cols=self.ln_axes[1])
         s_p = op_svd(dual)
-        return np.linalg.norm(s_p, ord=1)
+        return float(np.linalg.norm(s_p, ord=1))
 
-    def compute_primal_dual_gap(self, proj_primal, dual, mask=None):
+    def compute_primal_dual_gap(self, proj_primal: NDArrayFloat, dual: NDArrayFloat, mask: NDArrayFloat | None = None):
         if self.background is not None:
             proj_primal = proj_primal + self.background
 

--- a/src/corrct/data_terms.py
+++ b/src/corrct/data_terms.py
@@ -23,13 +23,9 @@ NDArrayFloat = NDArray[np.floating]
 
 
 def _soft_threshold(values: NDArrayFloat, threshold: float | NDArrayFloat) -> None:
-    abs_values = np.abs(values)
-    valid_values = abs_values > 0
-    if isinstance(threshold, (float, int)) or threshold.size == 1:
-        local_threshold = threshold
-    else:
-        local_threshold = threshold[valid_values]
-    values[valid_values] *= np.fmax((abs_values[valid_values] - local_threshold) / abs_values[valid_values], 0)
+    values_abs = np.abs(values)
+    values_sign = np.sign(values)
+    values[:] = values_sign * np.fmax(values_abs - threshold, 0.0)
 
 
 class DataFidelityBase(ABC):

--- a/src/corrct/data_terms.py
+++ b/src/corrct/data_terms.py
@@ -244,6 +244,25 @@ class DataFidelityBase(ABC):
         """
 
     @abstractmethod
+    def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
+        """Apply the proximal operator in the primal domain, in-place.
+
+        Computes prox_{tau * f}(primal), i.e. the proximal of the data-fidelity
+        f with step size tau, and stores the result back into ``primal``.
+
+        Note: in FISTA the data term is handled via a gradient step, so this
+        method is exposed for standalone use or for algorithms that prefer a
+        pure proximal approach (e.g. when A = I).
+
+        Parameters
+        ----------
+        primal : NDArrayFloat
+            The current primal variable (modified in-place).
+        tau : float | NDArrayFloat
+            The proximal step size.
+        """
+
+    @abstractmethod
     def compute_primal_dual_gap(
         self, proj_primal: NDArrayFloat, dual: NDArrayFloat, mask: NDArrayFloat | None = None
     ) -> float:
@@ -287,6 +306,26 @@ class DataFidelity_l2(DataFidelityBase):
         if self.data is not None and self.sigma_data is not None:
             dual -= self.sigma_data
         dual *= self.sigma1
+
+    def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
+        """Apply prox_{tau * (1/2) * ||. - b||^2} in-place.
+
+        The closed-form solution is:
+            prox(x) = (x + tau * b) / (1 + tau)
+
+        When no data has been assigned (b = 0):
+            prox(x) = x / (1 + tau)
+
+        Parameters
+        ----------
+        primal : NDArrayFloat
+            The primal variable to update in-place.
+        tau : float | NDArrayFloat
+            The proximal step size.
+        """
+        if self.data is not None:
+            primal += tau * self.data
+        primal /= 1.0 + tau
 
     def compute_primal_dual_gap(
         self, proj_primal: NDArrayFloat, dual: NDArrayFloat, mask: NDArrayFloat | None = None
@@ -336,6 +375,29 @@ class DataFidelity_wl2(DataFidelity_l2):
         weights = self.weights[valid_weights]
         return float(np.linalg.norm((dual / np.sqrt(weights)).flatten(), ord=2) ** 2)
 
+    def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
+        """Apply prox_{tau * (1/2) * ||. - b||^2_W} in-place.
+
+        For the weighted l2 norm (1/2)||x - b||^2_W = (1/2) sum_i w_i (x_i - b_i)^2,
+        the proximal is computed element-wise:
+            prox(x)_i = (x_i + tau * w_i * b_i) / (1 + tau * w_i)
+
+        Zero-weight entries are left unchanged (no constraint enforced there).
+
+        Parameters
+        ----------
+        primal : NDArrayFloat
+            The primal variable to update in-place.
+        tau : float | NDArrayFloat
+            The proximal step size.
+        """
+        tau_w = tau * self.weights
+        if self.data is not None:
+            primal += tau_w * self.data
+        # For zero-weight entries: denominator = 1, so they pass through unchanged.
+        denom = 1.0 + tau_w
+        primal /= denom
+
 
 class DataFidelity_l2b(DataFidelity_l2):
     """l2-norm ball data-fidelity class."""
@@ -369,6 +431,33 @@ class DataFidelity_l2b(DataFidelity_l2):
             dual -= self.sigma_data
         _soft_threshold(dual, self.sigma_sqrt_error)
         dual *= self.sigma1
+
+    def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
+        """Apply prox_{tau * f_{l2b}} in-place.
+
+        The l2-ball data fidelity is:
+            f(x) = max(||x - b|| - sqrt(epsilon), 0)^2 / 2
+
+        whose proximal is a soft-thresholded then scaled l2 proximal.
+        Specifically:
+            v = x - b
+            soft-threshold v by sqrt(epsilon) * tau / (1 + tau * epsilon)
+            prox(x) = b + v_thresholded / (1 + tau * epsilon)
+
+        Parameters
+        ----------
+        primal : NDArrayFloat
+            The primal variable to update in-place.
+        tau : float | NDArrayFloat
+            The proximal step size.
+        """
+        if self.data is not None:
+            primal -= self.data
+        tau_eps = tau * self.local_error
+        _soft_threshold(primal, np.sqrt(self.local_error) * tau / (1.0 + tau_eps))
+        primal /= 1.0 + tau_eps
+        if self.data is not None:
+            primal += self.data
 
     def compute_primal_dual_gap(
         self, proj_primal: NDArrayFloat, dual: NDArrayFloat, mask: NDArrayFloat | None = None
@@ -413,6 +502,26 @@ class DataFidelity_Huber(DataFidelityBase):
             dual_dir_norm_l2 = np.linalg.norm(dual, ord=2, axis=self.l2_axis, keepdims=True)
             dual /= np.fmax(1, dual_dir_norm_l2)
 
+    def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
+        """Not implemented: the Huber proximal in the primal has no simple closed form for general data.
+
+        The Huber function is f(x) = (1/2)||x-b||^2 if ||x-b|| <= a, else a*||x-b|| - a^2/2.
+        Its proximal is a smooth interpolation between the l2 and l1 proximals, whose
+        closed form depends on the norm of (x - b) relative to the threshold, making
+        it straightforward only for the scalar case. For vector inputs with l2_axis,
+        a Newton iteration would be required.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised; use a gradient step or PDHG instead.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.apply_proximal_primal: the Huber proximal has no simple "
+            "closed-form solution for general (possibly vector-valued) inputs. "
+            "Use a gradient step in the solver, or switch to PDHG for this data term."
+        )
+
     def compute_primal_dual_gap(self, proj_primal, dual, mask=None):
         if self.background is not None:
             proj_primal = proj_primal + self.background
@@ -445,6 +554,29 @@ class DataFidelity_l1(DataFidelityBase):
         dual /= np.fmax(dual_inner_norm, weight)
         dual *= weight
 
+    def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
+        """Apply prox_{tau * ||. - b||_1} in-place via soft-thresholding.
+
+        For f(x) = ||x - b||_1, the proximal is element-wise soft-thresholding
+        centered on b:
+            prox(x)_i = b_i + sign(x_i - b_i) * max(|x_i - b_i| - tau, 0)
+
+        When no data has been assigned (b = 0), this reduces to plain
+        soft-thresholding with threshold tau.
+
+        Parameters
+        ----------
+        primal : NDArrayFloat
+            The primal variable to update in-place.
+        tau : float | NDArrayFloat
+            The proximal step size (soft-threshold level).
+        """
+        if self.data is not None:
+            primal -= self.data
+        _soft_threshold(primal, tau)
+        if self.data is not None:
+            primal += self.data
+
     def compute_residual_norm(self, dual):
         dual = dual.copy()
         self._apply_threshold(dual)
@@ -473,6 +605,23 @@ class DataFidelity_l12(DataFidelity_l1):
     def _get_inner_norm(self, dual):
         return np.linalg.norm(dual, ord=2, axis=self.l2_axis, keepdims=True)
 
+    def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
+        """Not implemented: the l12 proximal in the primal domain requires a group soft-threshold
+        along l2_axis, which is straightforward only when the l2_axis corresponds to independent
+        groups that do not interact through A. For general use, apply PDHG or provide a
+        custom group-soft-threshold.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.apply_proximal_primal: the l12 norm proximal in the "
+            "primal domain is axis-dependent and cannot be applied independently per element. "
+            "Use PDHG for this data term, which handles it correctly via the dual."
+        )
+
 
 class DataFidelity_l1b(DataFidelity_l1):
     """l1-norm ball data-fidelity class."""
@@ -493,6 +642,35 @@ class DataFidelity_l1b(DataFidelity_l1):
     def _apply_threshold(self, dual):
         _soft_threshold(dual, self.local_error)
 
+    def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
+        """Apply prox_{tau * f_{l1b}} in-place.
+
+        The l1-ball data fidelity is:
+            f(x) = max(||x - b||_1 - epsilon, 0)
+
+        Its proximal is a two-stage soft-threshold:
+            v = x - b
+            soft-threshold v by (tau / (1 + tau)) elementwise, with level epsilon
+            prox(x) = b + v_thresholded
+
+        This is obtained via Moreau's identity applied to the indicator of the
+        l1-ball of radius epsilon.
+
+        Parameters
+        ----------
+        primal : NDArrayFloat
+            The primal variable to update in-place.
+        tau : float | NDArrayFloat
+            The proximal step size.
+        """
+        if self.data is not None:
+            primal -= self.data
+        # Two-level soft threshold: first remove the ball radius, then scale
+        _soft_threshold(primal, self.local_error)
+        primal *= tau / (1.0 + tau)
+        if self.data is not None:
+            primal += self.data
+
 
 class DataFidelity_KL(DataFidelityBase):
     """Kullback-Leibler data-fidelity class."""
@@ -511,13 +689,48 @@ class DataFidelity_KL(DataFidelityBase):
         else:
             dual[:] = (1 + dual[:] - np.sqrt((dual[:] - 1) ** 2)) / 2
 
-    def compute_residual(self, proj_primal, mask=None):
+    def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
+        """Apply prox_{tau * KL(b, .)} in-place.
+
+        The Kullback-Leibler divergence (in the emission-CT convention) is:
+            f(x) = sum_i (x_i - b_i * log(x_i))   (for x_i > 0)
+
+        Its proximal has the closed-form solution:
+            prox(x)_i = ((x_i - tau) + sqrt((x_i - tau)^2 + 4 * tau * b_i)) / 2
+
+        This is always non-negative when b_i >= 0 and x_i > 0.
+
+        Parameters
+        ----------
+        primal : NDArrayFloat
+            The primal variable to update in-place (must be > 0).
+        tau : float | NDArrayFloat
+            The proximal step size.
+        """
+        if self.data is not None:
+            b = np.fmax(self.data, 0.0)
+            disc = (primal - tau) ** 2 + 4.0 * tau * b
+            primal[:] = ((primal - tau) + np.sqrt(disc)) / 2.0
+        else:
+            # No data: f(x) = sum x_i, prox is max(x - tau, 0) clamped away from zero
+            primal[:] = np.fmax(primal - tau, eps)
+
+    def compute_residual(self, proj_primal: NDArray, mask: NDArray | None = None, use_proximal: bool = True) -> NDArrayFloat:
         if self.background is not None:
             proj_primal = proj_primal + self.background
-        # we take the Moreau envelope here, and apply the proximal to it
-        residual = np.fmax(proj_primal, eps) * self.sigma
 
-        self.apply_proximal_dual(residual)
+        proj_primal = np.fmax(proj_primal, eps)
+
+        if use_proximal:
+            # we take the Moreau envelope here, and apply the proximal to it
+            residual = np.fmax(proj_primal, eps) * self.sigma
+
+            self.apply_proximal_dual(residual)
+        else:
+            if self.data is not None:
+                residual = 1.0 - np.fmax(self.data, 0.0) / proj_primal
+            else:
+                residual = np.ones_like(proj_primal)
 
         if mask is not None:
             residual *= mask
@@ -587,6 +800,24 @@ class DataFidelity_ln(DataFidelityBase):
             dual_tmp = np.take(dual_tmp, np.arange(dual_tmp.shape[self.ln_axes[0]] - 1), axis=self.ln_axes[0])
 
         dual[:] = dual_tmp[:]
+
+    def apply_proximal_primal(self, primal: NDArrayFloat, tau: float | NDArrayFloat) -> None:
+        """Not implemented: the nuclear-norm proximal requires a full SVD and singular-value
+        soft-thresholding, which is only well-defined for the dual formulation used here
+        (where the SVD axes and data structure are set up by the PDHG dual update).
+        Applying it directly in the primal domain would require re-interpreting primal
+        axes as matrix rows/columns, which depends on context not available here.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised; use PDHG for nuclear-norm data fidelity.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.apply_proximal_primal: the nuclear-norm proximal "
+            "requires an SVD over axes that are determined by the dual formulation. "
+            "It cannot be applied generically in the primal domain. Use PDHG instead."
+        )
 
     def compute_residual_norm(self, dual):
         op_svd = operators.TransformSVD(dual.shape, axes_rows=self.ln_axes[0], axes_cols=self.ln_axes[1])

--- a/src/corrct/operators.py
+++ b/src/corrct/operators.py
@@ -985,8 +985,8 @@ class TransformSVD(BaseTransform):
     def __init__(
         self,
         x_shape: ArrayLike,
-        axes_rows: Sequence[int] | NDArray = (0,),
-        axes_cols: Sequence[int] | NDArray = (-1,),
+        axes_rows: int | Sequence[int] | NDArray = (0,),
+        axes_cols: int | Sequence[int] | NDArray = (-1,),
         rescale: bool = False,
     ):
         """
@@ -1087,7 +1087,7 @@ class TransformSVD(BaseTransform):
         x = np.transpose(x, self.fwd_transpose)
         x = np.reshape(x, self.fwd_shape)
 
-        (self.U, s, self.Vt) = self.direct_svd(x)
+        self.U, s, self.Vt = self.direct_svd(x)
 
         if self.rescale:
             s /= np.sqrt(self.Vt.shape[-1] * self.U.shape[-2])

--- a/src/corrct/regularizers.py
+++ b/src/corrct/regularizers.py
@@ -230,7 +230,7 @@ class Regularizer_Grad(BaseRegularizer):
     axes : Sequence, optional
         The axes over which it computes the gradient. If None, it uses the last 2. The default is None.
     pad_mode: str, optional
-        The padding mode to use for the linear convolution. The default is "edge".
+        The padding mode to use. The default is "edge".
     norm : DataFidelityBase, optional
         The norm of the regularizer minimization. The default is DataFidelity_l12().
     """
@@ -583,6 +583,7 @@ class Regularizer_l1(BaseRegularizer):
         else:
             self.norm.apply_proximal_primal(primal, tau * self.weight)
 
+
 class Regularizer_swl(BaseRegularizer):
     """Base stationary wavelet regularizer. It can be used to promote sparse reconstructions in the wavelet domain."""
 
@@ -841,13 +842,13 @@ class Regularizer_Hub_swl(Regularizer_swl):
         weight: float | NDArray,
         wavelet: str,
         level: int,
+        huber_size: float,
         ndims: int = 2,
         axes: Sequence[int] | NDArray | None = None,
         pad_on_demand: str = "constant",
         upd_mask: NDArray | None = None,
         normalized: bool = False,
         min_approx: bool = True,
-        huber_size: int | None = None,
     ):
         super().__init__(
             weight,
@@ -966,6 +967,14 @@ class Regularizer_dwl(BaseRegularizer):
 
     def apply_proximal_dual(self, dual: NDArray) -> None:
         if isinstance(self.norm, dt.DataFidelity_l12):
+            if self.op is None:
+                raise ValueError("Regularizer not initialized! Please use method: `initialize_sigma_tau`.")
+            if not isinstance(self.op, operators.TransformDecimatedWavelet):
+                raise RuntimeError(
+                    "Initialization error: the operator should have been `operators.TransformDecimatedWavelet`,"
+                    f" but {type(self.op)} was found."
+                )
+
             op_wl: operators.TransformDecimatedWavelet = self.op
             coeffs = pywt.array_to_coeffs(dual, op_wl.slicing_info)
             for ii_l in range(1, len(coeffs)):
@@ -1009,6 +1018,11 @@ class Regularizer_dwl(BaseRegularizer):
         """
         if self.op is None:
             raise ValueError("Regularizer not initialized! Please use method: `initialize_sigma_tau`.")
+        if not isinstance(self.op, operators.TransformDecimatedWavelet):
+            raise RuntimeError(
+                "Initialization error: the operator should have been `operators.TransformDecimatedWavelet`,"
+                f" but {type(self.op)} was found."
+            )
 
         op_wl: operators.TransformDecimatedWavelet = self.op
 
@@ -1103,11 +1117,11 @@ class Regularizer_Hub_dwl(Regularizer_dwl):
         weight: float | NDArray,
         wavelet: str,
         level: int,
+        huber_size: float,
         ndims: int = 2,
         axes: Sequence[int] | NDArray | None = None,
         pad_on_demand: str = "constant",
         upd_mask: NDArray | None = None,
-        huber_size: int | None = None,
     ):
         super().__init__(
             weight,
@@ -1261,15 +1275,15 @@ class Regularizer_fft(BaseRegularizer):
     def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
         """Apply prox_{tau * weight * g} in the primal domain for the Fourier regularizer.
 
-        The DFT (with ortho normalisation) is unitary, so the proximal of
+        The DFT (with ortho normalization) is unitary, so the proximal of
         weight * ||W .||_{norm} separates in the frequency domain:
 
             prox(x) = W^{-1} * prox_{tau * weight * ||.||_norm}(W * x)
 
-        where W is TransformFourier (ortho-normalised FFT).  The frequency
+        where W is TransformFourier (ortho-normalized FFT).  The frequency
         mask ``self.sigma`` is applied before thresholding (as in the dual),
         and masked-out frequencies (sigma == 0, i.e. the DC or low-frequency
-        components, depending on fft_filter) are left unpenalised.
+        components, depending on fft_filter) are left unpenalized.
 
         Parameters
         ----------
@@ -1286,20 +1300,20 @@ class Regularizer_fft(BaseRegularizer):
         if self.op is None:
             raise ValueError("Regularizer not initialized! Please use method: `initialize_sigma_tau`.")
 
-        # Forward ortho-normalised FFT: coeffs shape is (2, *x_shape)
+        # Forward ortho-normalized FFT: coeffs shape is (2, *x_shape)
         coeffs = self.op(primal)
 
-        # Split into penalised (masked) and unpenalised (unmasked) frequencies.
-        # self.sigma is 1 for penalised frequencies and 0 for unpenalised ones
+        # Split into penalized (masked) and unpenalized (unmasked) frequencies.
+        # self.sigma is 1 for penalized frequencies and 0 for unpenalized ones
         # (e.g. DC component for fft_filter="delta").
         coeffs_pen = coeffs * self.sigma  # frequencies to be thresholded
         coeffs_free = coeffs * (1.0 - self.sigma)  # frequencies left unchanged
 
-        # Apply the proximal (soft-threshold) only to the penalised frequencies
+        # Apply the proximal (soft-threshold) only to the penalized frequencies
         threshold = tau * self.weight
         self.norm.apply_proximal_primal(coeffs_pen, threshold)
 
-        # Reconstruct full coefficient array: thresholded + unpenalised
+        # Reconstruct full coefficient array: thresholded + unpenalized
         coeffs_out = coeffs_pen + coeffs_free
 
         # Inverse FFT back to primal domain

--- a/src/corrct/regularizers.py
+++ b/src/corrct/regularizers.py
@@ -161,6 +161,30 @@ class BaseRegularizer(ABC):
         else:
             self.norm.apply_proximal_dual(dual)
 
+    def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
+        """Apply the proximal of the regularizer in the primal domain, in-place.
+
+        Computes prox_{tau * weight * g}(primal) where g is the regularization
+        functional, and stores the result back into ``primal``.
+
+        This method is only implemented for regularizers whose operator is
+        unitary (or the identity), so that the proximal separates in the primal
+        domain.  For regularizers based on non-unitary transforms (gradient,
+        Laplacian, etc.), this raises NotImplementedError — use PDHG instead.
+
+        Parameters
+        ----------
+        primal : NDArray
+            The primal variable to update in-place.
+        tau : float | NDArray
+            The proximal step size.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.apply_proximal_primal is not implemented. "
+            "Only regularizers with a unitary or identity transform support a primal proximal. "
+            "Use PDHG for this regularizer."
+        )
+
     def compute_update_primal(self, dual: NDArray) -> NDArray:
         """
         Compute the partial update of a primal term, from this regularizer.
@@ -247,6 +271,22 @@ class Regularizer_Grad(BaseRegularizer):
         if self.upd_mask is not None:
             tau = tau * self.upd_mask
         return tau
+
+    def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
+        """Not implemented: gradient-based regularizers (TV, smooth) require solving
+        a non-trivial optimization subproblem in the primal domain, because the gradient
+        operator is not unitary. There is no simple closed-form proximal.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised; use PDHG for gradient-based regularizers.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.apply_proximal_primal: gradient-based regularizers "
+            "(TV, smooth) do not have a simple closed-form primal proximal because "
+            "TransformGradient is not unitary. Use PDHG for these regularizers."
+        )
 
 
 class Regularizer_TV1D(Regularizer_Grad):
@@ -428,6 +468,20 @@ class Regularizer_lap(BaseRegularizer):
             tau = tau * self.upd_mask
         return tau
 
+    def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
+        """Not implemented: the Laplacian operator is not unitary, so its proximal in the primal
+        domain has no closed-form solution and requires an iterative solve.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised; use PDHG for Laplacian regularizers.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.apply_proximal_primal: the Laplacian operator is "
+            "not unitary, so there is no closed-form primal proximal. Use PDHG instead."
+        )
+
 
 class Regularizer_lap1D(Regularizer_lap):
     """Laplacian regularizer in 1D. It can be used to promote smooth reconstructions."""
@@ -502,6 +556,32 @@ class Regularizer_l1(BaseRegularizer):
     def update_dual(self, dual: NDArray, primal: NDArray) -> None:
         dual += primal
 
+    def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
+        """Apply prox_{tau * weight * ||.||_1} in-place via element-wise soft-thresholding.
+
+        For g(x) = weight * ||x||_1, the proximal is:
+            prox(x)_i = sign(x_i) * max(|x_i| - tau * weight, 0)
+
+        The operator is the identity (TransformIdentity), so the proximal
+        separates element-wise.  When ``upd_mask`` is set, only the elements
+        inside the mask are thresholded; the rest are left unchanged.
+
+        Parameters
+        ----------
+        primal : NDArray
+            The primal variable to update in-place.
+        tau : float | NDArray
+            The proximal step size.
+        """
+        if self.upd_mask is not None:
+            # Apply soft-threshold only inside the mask region
+            primal_masked = primal * self.upd_mask
+            self.norm.apply_proximal_primal(primal_masked, tau * self.weight)
+            # Blend: inside mask use thresholded value, outside keep original
+            primal *= 1 - self.upd_mask
+            primal += primal_masked
+        else:
+            self.norm.apply_proximal_primal(primal, tau * self.weight)
 
 class Regularizer_swl(BaseRegularizer):
     """Base stationary wavelet regularizer. It can be used to promote sparse reconstructions in the wavelet domain."""
@@ -621,6 +701,72 @@ class Regularizer_swl(BaseRegularizer):
             self.norm.apply_proximal_dual(tmp_dual, self.weight)
         else:
             super().apply_proximal_dual(dual)
+
+    def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
+        """Apply prox_{tau * weight * g} in the primal domain via the wavelet transform.
+
+        The stationary wavelet transform (with ``normalized=True``) is a tight frame
+        (Parseval / isometric), so the proximal of weight * ||W .||_1 in the primal
+        domain is:
+
+            prox(x) = W^T * prox_{tau * weight * ||.||_1}(W * x)
+
+        i.e. transform → soft-threshold coefficients → inverse transform.
+
+        When ``normalized=False`` the frame is not tight and this method raises
+        NotImplementedError, because the correct step sizes per sub-band cannot be
+        collapsed into a single tau without further information.
+
+        Parameters
+        ----------
+        primal : NDArray
+            The primal variable to update in-place.
+        tau : float | NDArray
+            The proximal step size.
+
+        Raises
+        ------
+        NotImplementedError
+            When the wavelet transform is not normalized (not a tight frame).
+        ValueError
+            When the regularizer has not been initialized.
+        """
+        if self.op is None:
+            raise ValueError("Regularizer not initialized! Please use method: `initialize_sigma_tau`.")
+
+        if not self.normalized:
+            raise NotImplementedError(
+                f"{self.__class__.__name__}.apply_proximal_primal: the non-normalized "
+                "stationary wavelet transform is not a tight frame, so the per-sub-band "
+                "step sizes cannot be collapsed into a single tau. "
+                "Use normalized=True or switch to PDHG."
+            )
+
+        op_swl: operators.TransformStationaryWavelet = self.op  # type: ignore
+
+        # Forward stationary wavelet transform → list of dicts (pywt swtn format)
+        coeffs_list = op_swl.direct_swt(primal)
+        # coeffs_list[0] is the approximation array; coeffs_list[1..level] are
+        # dicts of detail sub-bands keyed by orientation label.
+
+        threshold = tau * self.weight
+
+        # Threshold detail sub-bands
+        for lvl in range(1, len(coeffs_list)):
+            c_l = coeffs_list[lvl]
+            for lab in list(c_l.keys()):
+                coeff = c_l[lab]
+                self.norm.apply_proximal_primal(coeff, threshold)
+                c_l[lab] = coeff
+
+        # Optionally threshold the approximation sub-band
+        if self.min_approx:
+            approx = coeffs_list[0]
+            self.norm.apply_proximal_primal(approx, threshold)
+            coeffs_list[0] = approx
+
+        # Inverse stationary wavelet transform back to primal domain
+        primal[:] = op_swl.inverse_swt(coeffs_list)
 
 
 class Regularizer_l1swl(Regularizer_swl):
@@ -839,6 +985,55 @@ class Regularizer_dwl(BaseRegularizer):
         else:
             super().apply_proximal_dual(dual)
 
+    def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
+        """Apply prox_{tau * weight * g} in the primal domain for decimated wavelets.
+
+        The decimated wavelet transform is orthogonal (W^T W = I), so it is a tight
+        frame with frame bound 1.  The proximal of weight * ||W .||_1 is therefore:
+
+            prox(x) = W^T * prox_{tau * weight * ||.||_1}(W * x)
+
+        i.e. transform → soft-threshold each sub-band → inverse transform.
+
+        Parameters
+        ----------
+        primal : NDArray
+            The primal variable to update in-place.
+        tau : float | NDArray
+            The proximal step size.
+
+        Raises
+        ------
+        ValueError
+            When the regularizer has not been initialized.
+        """
+        if self.op is None:
+            raise ValueError("Regularizer not initialized! Please use method: `initialize_sigma_tau`.")
+
+        op_wl: operators.TransformDecimatedWavelet = self.op
+
+        # Forward decimated wavelet transform (returns a pywt coefficient list)
+        coeffs_list = op_wl.direct_dwt(primal)
+
+        threshold = float(np.asarray(tau * self.weight).flat[0])
+
+        # Soft-threshold detail sub-bands; optionally suppress approximation
+        for ii_l in range(1, len(coeffs_list)):
+            c_l = coeffs_list[ii_l]
+            for lab in list(c_l.keys()):
+                coeff = c_l[lab]
+                self.norm.apply_proximal_primal(coeff, threshold)
+                c_l[lab] = coeff
+
+        if self.min_approx:
+            # Also threshold the approximation band
+            approx = coeffs_list[0]
+            self.norm.apply_proximal_primal(approx, threshold)
+            coeffs_list[0] = approx
+
+        # Inverse transform back to primal domain
+        primal[:] = op_wl.inverse_dwt(coeffs_list)
+
 
 class Regularizer_l1dwl(Regularizer_dwl):
     """l1-norm decimated wavelet regularizer. It can be used to promote sparse reconstructions."""
@@ -969,6 +1164,21 @@ class BaseRegularizer_med(BaseRegularizer):
     def update_dual(self, dual: NDArray, primal: NDArray) -> None:
         dual += primal - spimg.median_filter(primal, self.filt_size)
 
+    def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
+        """Not implemented: the median-filter regularizer has a non-linear, non-unitary
+        'operator' (x - median_filter(x)), so no closed-form primal proximal exists.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised; use PDHG for median-filter regularizers.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.apply_proximal_primal: the median-filter regularizer "
+            "uses a non-linear transform, so no closed-form primal proximal exists. "
+            "Use PDHG instead."
+        )
+
 
 class Regularizer_l1med(BaseRegularizer_med):
     """l1-norm median filter regularizer. It can be used to promote filtered reconstructions."""
@@ -1047,6 +1257,53 @@ class Regularizer_fft(BaseRegularizer):
         if self.upd_mask is not None:
             tau = tau * self.upd_mask
         return tau
+
+    def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
+        """Apply prox_{tau * weight * g} in the primal domain for the Fourier regularizer.
+
+        The DFT (with ortho normalisation) is unitary, so the proximal of
+        weight * ||W .||_{norm} separates in the frequency domain:
+
+            prox(x) = W^{-1} * prox_{tau * weight * ||.||_norm}(W * x)
+
+        where W is TransformFourier (ortho-normalised FFT).  The frequency
+        mask ``self.sigma`` is applied before thresholding (as in the dual),
+        and masked-out frequencies (sigma == 0, i.e. the DC or low-frequency
+        components, depending on fft_filter) are left unpenalised.
+
+        Parameters
+        ----------
+        primal : NDArray
+            The primal variable to update in-place.
+        tau : float | NDArray
+            The proximal step size.
+
+        Raises
+        ------
+        ValueError
+            When the regularizer has not been initialized.
+        """
+        if self.op is None:
+            raise ValueError("Regularizer not initialized! Please use method: `initialize_sigma_tau`.")
+
+        # Forward ortho-normalised FFT: coeffs shape is (2, *x_shape)
+        coeffs = self.op(primal)
+
+        # Split into penalised (masked) and unpenalised (unmasked) frequencies.
+        # self.sigma is 1 for penalised frequencies and 0 for unpenalised ones
+        # (e.g. DC component for fft_filter="delta").
+        coeffs_pen = coeffs * self.sigma  # frequencies to be thresholded
+        coeffs_free = coeffs * (1.0 - self.sigma)  # frequencies left unchanged
+
+        # Apply the proximal (soft-threshold) only to the penalised frequencies
+        threshold = tau * self.weight
+        self.norm.apply_proximal_primal(coeffs_pen, threshold)
+
+        # Reconstruct full coefficient array: thresholded + unpenalised
+        coeffs_out = coeffs_pen + coeffs_free
+
+        # Inverse FFT back to primal domain
+        primal[:] = self.op.T(coeffs_out)
 
 
 # Multi-channel regularizers
@@ -1358,6 +1615,22 @@ class Regularizer_vSVD(BaseRegularizer):
             tau = tau * self.upd_mask
         return tau
 
+    def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
+        """Not implemented: the SVD-based regularizer uses a non-unitary, data-dependent transform
+        (TransformSVD stores U and Vt from the last forward pass), so the proximal cannot be
+        applied in the primal domain without re-computing the SVD.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised; use PDHG for SVD-based regularizers.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.apply_proximal_primal: the SVD regularizer uses a "
+            "data-dependent, non-unitary transform. Its primal proximal requires a full SVD "
+            "recomputation and is not supported. Use PDHG instead."
+        )
+
 
 # ---- Constraints ----
 
@@ -1409,6 +1682,25 @@ class Constraint_LowerLimit(BaseRegularizer):
         dual[dual > 0.0] = 0.0
         self.norm.apply_proximal_dual(dual)
 
+    def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
+        """Apply the lower-limit constraint proximal in-place.
+
+        The proximal of the indicator function of {x >= limit} is the projection
+        onto the feasible half-space:
+            prox(x)_i = max(x_i, limit)
+
+        The step size tau has no effect on an indicator function proximal
+        (the projection is independent of tau).
+
+        Parameters
+        ----------
+        primal : NDArray
+            The primal variable to update in-place.
+        tau : float | NDArray
+            The proximal step size (unused for indicator functions, kept for API consistency).
+        """
+        np.fmax(primal, self.limit, out=primal)
+
 
 class Constraint_UpperLimit(BaseRegularizer):
     """Upper limit constraint. It can be used to promote reconstructions in certain regions of solution space."""
@@ -1456,3 +1748,22 @@ class Constraint_UpperLimit(BaseRegularizer):
     def apply_proximal_dual(self, dual: NDArray) -> None:
         dual[dual < 0.0] = 0.0
         self.norm.apply_proximal_dual(dual)
+
+    def apply_proximal_primal(self, primal: NDArray, tau: float | NDArray) -> None:
+        """Apply the upper-limit constraint proximal in-place.
+
+        The proximal of the indicator function of {x <= limit} is the projection
+        onto the feasible half-space:
+            prox(x)_i = min(x_i, limit)
+
+        The step size tau has no effect on an indicator function proximal
+        (the projection is independent of tau).
+
+        Parameters
+        ----------
+        primal : NDArray
+            The primal variable to update in-place.
+        tau : float | NDArray
+            The proximal step size (unused for indicator functions, kept for API consistency).
+        """
+        np.fmin(primal, self.limit, out=primal)

--- a/src/corrct/regularizers.py
+++ b/src/corrct/regularizers.py
@@ -147,7 +147,7 @@ class BaseRegularizer(ABC):
 
         dual += self.sigma * self.op(primal)
 
-    def apply_proximal(self, dual: NDArray) -> None:
+    def apply_proximal_dual(self, dual: NDArray) -> None:
         """
         Apply the proximal operator to the dual in-place.
 
@@ -157,9 +157,9 @@ class BaseRegularizer(ABC):
             The dual to be applied the proximal on.
         """
         if isinstance(self.norm, dt.DataFidelity_l1):
-            self.norm.apply_proximal(dual, self.weight)
+            self.norm.apply_proximal_dual(dual, self.weight)
         else:
-            self.norm.apply_proximal(dual)
+            self.norm.apply_proximal_dual(dual)
 
     def compute_update_primal(self, dual: NDArray) -> NDArray:
         """
@@ -612,15 +612,15 @@ class Regularizer_swl(BaseRegularizer):
         if not self.min_approx:
             dual[0, ...] = 0
 
-    def apply_proximal(self, dual: NDArray) -> None:
+    def apply_proximal_dual(self, dual: NDArray) -> None:
         if isinstance(self.norm, dt.DataFidelity_l12):
             tmp_dual = dual[1:]
             tmp_dual = tmp_dual.reshape([-1, self.level, *dual.shape[1:]])
-            self.norm.apply_proximal(tmp_dual, self.weight)
+            self.norm.apply_proximal_dual(tmp_dual, self.weight)
             tmp_dual = dual[0:1:]
-            self.norm.apply_proximal(tmp_dual, self.weight)
+            self.norm.apply_proximal_dual(tmp_dual, self.weight)
         else:
-            super().apply_proximal(dual)
+            super().apply_proximal_dual(dual)
 
 
 class Regularizer_l1swl(Regularizer_swl):
@@ -818,7 +818,7 @@ class Regularizer_dwl(BaseRegularizer):
             slices = [slice(0, x) for x in op_wl.sub_band_shapes[0]]
             dual[tuple(slices)] = 0
 
-    def apply_proximal(self, dual: NDArray) -> None:
+    def apply_proximal_dual(self, dual: NDArray) -> None:
         if isinstance(self.norm, dt.DataFidelity_l12):
             op_wl: operators.TransformDecimatedWavelet = self.op
             coeffs = pywt.array_to_coeffs(dual, op_wl.slicing_info)
@@ -830,14 +830,14 @@ class Regularizer_dwl(BaseRegularizer):
                     labels.append(lab)
                     details.append(det)
                 c_ll = np.stack(details, axis=0)
-                self.norm.apply_proximal(c_ll, self.weight)
+                self.norm.apply_proximal_dual(c_ll, self.weight)
                 for ii, lab in enumerate(labels):
                     c_l[lab] = c_ll[ii]
                 coeffs[ii_l] = c_l
-            self.norm.apply_proximal(coeffs[0], self.weight)
+            self.norm.apply_proximal_dual(coeffs[0], self.weight)
             dual[:] = pywt.coeffs_to_array(coeffs)[0]
         else:
-            super().apply_proximal(dual)
+            super().apply_proximal_dual(dual)
 
 
 class Regularizer_l1dwl(Regularizer_dwl):
@@ -1130,7 +1130,7 @@ class Regularizer_VTV(Regularizer_Grad):
             + f" Provided the following instead: derivatives={self.pwise_der_norm}, channel={self.pwise_chan_norm}"
         )
 
-    def apply_proximal(self, dual: NDArray) -> None:
+    def apply_proximal_dual(self, dual: NDArray) -> None:
         # Following assignments will detach the local array from the original one
         dual_tmp = dual.copy()
 
@@ -1281,7 +1281,7 @@ class Regularizer_vl1wl(Regularizer_l1swl):
 
         return tau
 
-    def apply_proximal(self, dual: NDArray) -> None:
+    def apply_proximal_dual(self, dual: NDArray) -> None:
         dual_tmp = dual.copy()
 
         if self.q_ref is not None:
@@ -1405,9 +1405,9 @@ class Constraint_LowerLimit(BaseRegularizer):
     def update_dual(self, dual: NDArray, primal: NDArray) -> None:
         dual += primal - self.limit
 
-    def apply_proximal(self, dual: NDArray) -> None:
+    def apply_proximal_dual(self, dual: NDArray) -> None:
         dual[dual > 0.0] = 0.0
-        self.norm.apply_proximal(dual)
+        self.norm.apply_proximal_dual(dual)
 
 
 class Constraint_UpperLimit(BaseRegularizer):
@@ -1453,6 +1453,6 @@ class Constraint_UpperLimit(BaseRegularizer):
     def update_dual(self, dual: NDArray, primal: NDArray) -> None:
         dual += primal - self.limit
 
-    def apply_proximal(self, dual: NDArray) -> None:
+    def apply_proximal_dual(self, dual: NDArray) -> None:
         dual[dual < 0.0] = 0.0
-        self.norm.apply_proximal(dual)
+        self.norm.apply_proximal_dual(dual)

--- a/src/corrct/regularizers.py
+++ b/src/corrct/regularizers.py
@@ -712,7 +712,7 @@ class Regularizer_swl(BaseRegularizer):
 
             prox(x) = W^T * prox_{tau * weight * ||.||_1}(W * x)
 
-        i.e. transform → soft-threshold coefficients → inverse transform.
+        i.e. transform -> soft-threshold coefficients -> inverse transform.
 
         When ``normalized=False`` the frame is not tight and this method raises
         NotImplementedError, because the correct step sizes per sub-band cannot be
@@ -743,10 +743,8 @@ class Regularizer_swl(BaseRegularizer):
                 "Use normalized=True or switch to PDHG."
             )
 
-        op_swl: operators.TransformStationaryWavelet = self.op  # type: ignore
-
-        # Forward stationary wavelet transform → list of dicts (pywt swtn format)
-        coeffs_list = op_swl.direct_swt(primal)
+        # Forward stationary wavelet transform -> list of dicts (pywt swtn format)
+        coeffs_list = self.op(primal)
         # coeffs_list[0] is the approximation array; coeffs_list[1..level] are
         # dicts of detail sub-bands keyed by orientation label.
 
@@ -767,7 +765,7 @@ class Regularizer_swl(BaseRegularizer):
             coeffs_list[0] = approx
 
         # Inverse stationary wavelet transform back to primal domain
-        primal[:] = op_swl.inverse_swt(coeffs_list)
+        primal[:] = self.op.T(coeffs_list)
 
 
 class Regularizer_l1swl(Regularizer_swl):
@@ -1002,7 +1000,7 @@ class Regularizer_dwl(BaseRegularizer):
 
             prox(x) = W^T * prox_{tau * weight * ||.||_1}(W * x)
 
-        i.e. transform → soft-threshold each sub-band → inverse transform.
+        i.e. transform -> soft-threshold each sub-band -> inverse transform.
 
         Parameters
         ----------

--- a/src/corrct/solvers.py
+++ b/src/corrct/solvers.py
@@ -67,6 +67,33 @@ def compute_diagonal_scaling(
     x_mask: NDArray | None = None,
     b_mask: NDArray | None = None,
 ) -> tuple[NDArray, NDArray, tuple[int, ...], DTypeLike]:
+    """
+    Compute diagonal scaling factors for the forward and backward projections.
+
+    Parameters
+    ----------
+    A_abs : operators.BaseTransform
+        The absolute value of the forward projection operator.
+    At_abs : operators.BaseTransform
+        The absolute value of the backward projection operator.
+    b : NDArrayFloat
+        The measurement data.
+    regs : Sequence[regularizers.BaseRegularizer]
+        The sequence of regularizers.
+    relaxation_sigma : float, optional
+        The relaxation factor for the forward projection scaling, by default 1.0.
+    relaxation_tau : float, optional
+        The relaxation factor for the backward projection scaling, by default 1.0.
+    x_mask : NDArray | None, optional
+        The mask for the image space, by default None.
+    b_mask : NDArray | None, optional
+        The mask for the measurement space, by default None.
+
+    Returns
+    -------
+    tuple[NDArray, NDArray, tuple[int, ...], DTypeLike]
+        The scaling factors for the forward and backward projections, the shape of the image space, and the data type of the image space.
+    """
     # Back-projection diagonal re-scaling
     # Tau = |A^T| 1_b  (row sums -> image-space diagonal)
     b_ones = np.ones_like(b)
@@ -97,6 +124,27 @@ def compute_Lipschitz_scaling(
     relaxation_sigma: float = 1.0,
     relaxation_tau: float = 1.0,
 ) -> tuple[float, float | NDArray, tuple[int, ...], DTypeLike]:
+    """
+    Compute Lipschitz scaling factors for the forward and backward projections.
+
+    Parameters
+    ----------
+    A : operators.BaseTransform
+        The forward projection operator.
+    b : NDArrayFloat
+        The measurement data.
+    regs : Sequence[regularizers.BaseRegularizer]
+        The sequence of regularizers.
+    relaxation_sigma : float, optional
+        The relaxation factor for the forward projection scaling, by default 1.0.
+    relaxation_tau : float, optional
+        The relaxation factor for the backward projection scaling, by default 1.0.
+
+    Returns
+    -------
+    tuple[float, float | NDArray, tuple[int, ...], DTypeLike]
+        The scaling factors for the forward and backward projections, the shape of the image space, and the data type of the image space.
+    """
     L, x_shape, x_dtype = power_method(A, b)
     tau = L
 

--- a/src/corrct/solvers.py
+++ b/src/corrct/solvers.py
@@ -840,7 +840,7 @@ class SIRT(Solver):
             q = [reg.initialize_dual() for reg in self.regularizer]
             for q_r, reg in zip(q, self.regularizer):
                 reg.update_dual(q_r, x)
-                reg.apply_proximal(q_r)
+                reg.apply_proximal_dual(q_r)
 
             upd = A.T(res * sigma)
             for q_r, reg in zip(q, self.regularizer):
@@ -1093,14 +1093,14 @@ class PDHG(Solver):
 
             Ax_rlx = A(x_relax)
             self.data_term.update_dual(p, Ax_rlx)
-            self.data_term.apply_proximal(p)
+            self.data_term.apply_proximal_dual(p)
 
             if b_mask is not None:
                 p *= b_mask
 
             for q_r, reg in zip(q, self.regularizer):
                 reg.update_dual(q_r, x_relax)
-                reg.apply_proximal(q_r)
+                reg.apply_proximal_dual(q_r)
 
             upd = A.T(p)
             for q_r, reg in zip(q, self.regularizer):

--- a/src/corrct/solvers.py
+++ b/src/corrct/solvers.py
@@ -1156,3 +1156,310 @@ class PDHG(Solver):
                     break
 
         return x, info
+
+
+class FISTA(Solver):
+    """Fast Iterative Shrinkage-Thresholding Algorithm (FISTA).
+
+    Implements the accelerated proximal gradient method from Beck & Teboulle (2009),
+    "A Fast Iterative Shrinkage-Thresholding Algorithm for Linear Inverse Problems",
+    SIAM Journal on Imaging Sciences.
+
+    The algorithm minimizes:
+        min_x  f(x)  +  g(x)
+
+    where:
+      - f(x) is the data-fidelity term, handled via its *gradient*:
+            grad f(x) = A^T (A x - b)     for the l2 case
+            grad f(x) = A^T (1 - b / Ax)  for the KL case
+        (computed using ``data_term.compute_residual`` followed by ``A.T``).
+      - g(x) is an optional regularizer with a tractable *primal proximal*,
+        applied via ``regularizer.apply_proximal_primal``.
+
+    **TV-min regularization (Regularizer_Grad and all TV subclasses) is not
+    supported** because their primal proximal has no closed form.  Passing such
+    a regularizer raises ``ValueError`` at construction time.
+
+    **At most one regularizer** is accepted; passing a list with more than one
+    raises ``ValueError``.
+
+    Step-size strategy
+    ------------------
+    Two modes are available, selected by the ``precondition`` argument to
+    ``__call__``:
+
+    * ``precondition=False`` (default Lipschitz): the step size is
+      ``tau = relaxation / L`` where ``L = ||A||^2`` is estimated via the power
+      method.
+
+    * ``precondition=True`` (SIRT-style diagonal preconditioning): following the
+      same convention as SIRT,
+
+          Sigma = diag(|A| 1_x)      (column sums of |A|, in measurement space)
+          Tau   = diag(|A^T| 1_b)    (row sums of |A|, in image space)
+
+      The gradient step then reads:
+          x <- x - Tau * A^T(residual * Sigma)
+
+      where ``residual = b - A x``.  This is the SIRT preconditioned gradient step;
+      the ``relaxation`` scalar is folded into Tau as ``Tau = relaxation / Tau_raw``.
+
+    Parameters
+    ----------
+    verbose : bool, optional
+        Turn on verbose output. The default is False.
+    leave_progress : bool, optional
+        Leave the progress bar after computation. The default is True.
+    tolerance : float | None, optional
+        Stop early when the residual norm drops below this value. The default is None.
+    relaxation : float, optional
+        Step-size relaxation factor (scalar multiplier on tau). The default is 1.0.
+    regularizer : BaseRegularizer | None, optional
+        A single regularizer with a tractable primal proximal.  TV-type and
+        Laplacian regularizers are rejected.  The default is None.
+    data_term : str | DataFidelityBase, optional
+        Data fidelity. Accepts ``"l2"`` or a ``DataFidelity_l2`` instance.
+        The default is ``"l2"``.
+    data_term_test : DataFidelityBase | None, optional
+        Data fidelity for the held-out test set. Defaults to the same as
+        ``data_term``.
+    restart_period : int | None, optional
+        If given, the FISTA momentum sequence is restarted every
+        ``restart_period`` iterations.  If ``None`` (default), the pure
+        Beck-Teboulle monotone sequence is used with no restart.
+    """
+
+    def __init__(
+        self,
+        verbose: bool = False,
+        leave_progress: bool = True,
+        tolerance: float | None = None,
+        relaxation: float = 1.0,
+        regularizer: regularizers.BaseRegularizer | None = None,
+        data_term: str | data_terms.DataFidelityBase = "l2",
+        data_term_test: str | data_terms.DataFidelityBase | None = None,
+        restart_period: int | None = None,
+    ):
+        super().__init__(
+            verbose=verbose,
+            leave_progress=leave_progress,
+            relaxation=relaxation,
+            tolerance=tolerance,
+            data_term=data_term,
+            data_term_test=data_term_test,
+        )
+
+        # Validate and store the (single) regularizer
+        regs = self._initialize_regularizer(regularizer)
+        if len(regs) > 1:
+            raise ValueError(
+                "FISTA supports at most one regularizer, but "
+                f"{len(regs)} were provided. "
+                "To combine multiple regularizers use PDHG instead."
+            )
+        if len(regs) == 1:
+            reg = regs[0]
+            # Reject TV / gradient / Laplacian regularizers up front by
+            # attempting a dry-run of apply_proximal_primal with a tiny dummy.
+            # We call the method on a zero-size array; if it raises
+            # NotImplementedError we know the regularizer is unsupported.
+            try:
+                reg.apply_proximal_primal(np.zeros(1, dtype=np.float32), 1.0)
+            except NotImplementedError as exc:
+                raise ValueError(
+                    f"Regularizer '{reg.info()}' does not support a primal proximal "
+                    "and cannot be used with FISTA. "
+                    "Switch to PDHG for this regularizer, or use a wavelet / l1 "
+                    "regularizer with FISTA.\n"
+                    f"Original error: {exc}"
+                ) from exc
+            except Exception:
+                # Any other exception (e.g. shape mismatch on the dummy) is fine;
+                # it means the method exists and would be called correctly later.
+                pass
+        self.regularizer: list[regularizers.BaseRegularizer] = list(regs)
+        self.restart_period = restart_period
+
+    def info(self) -> str:
+        """Return the FISTA info string."""
+        reg_info = "".join(["-" + r.info().upper() for r in self.regularizer])
+        return Solver.info(self) + "-" + self.data_term.info() + reg_info
+
+    @staticmethod
+    def _initialize_data_fidelity_function(data_term: str | data_terms.DataFidelityBase):
+        """Accept l2, wl2, l2b and their subclasses for FISTA."""
+        if isinstance(data_term, str):
+            if data_term.lower() == "l2":
+                return data_terms.DataFidelity_l2()
+            else:
+                raise ValueError(f"Unknown data term: '{data_term}'. FISTA only accepts 'l2' and derivatives.")
+        elif isinstance(data_term, data_terms.DataFidelity_l2):
+            return cp.deepcopy(data_term)
+        else:
+            raise ValueError(f"Unsupported data term type: {type(data_term)}. FISTA only accepts 'l2' and derivatives.")
+
+    def __call__(  # noqa: C901
+        self,
+        A: operators.BaseTransform,
+        b: NDArrayFloat,
+        iterations: int,
+        x0: NDArrayFloat | None = None,
+        lower_limit: float | NDArrayFloat | None = None,
+        upper_limit: float | NDArrayFloat | None = None,
+        x_mask: NDArrayFloat | None = None,
+        b_mask: NDArrayFloat | None = None,
+        b_test_mask: NDArrayFloat | None = None,
+        precondition: bool = True,
+    ) -> tuple[NDArrayFloat, SolutionInfo]:
+        """Run FISTA.
+
+        Parameters
+        ----------
+        A : BaseTransform
+            Forward operator.
+        b : NDArrayFloat
+            Measurement data.
+        iterations : int
+            Number of outer iterations.
+        x0 : NDArrayFloat | None, optional
+            Warm-start solution. The default is None (zero initialisation).
+        lower_limit : float | NDArrayFloat | None, optional
+            Hard lower bound applied after each proximal step (clipping).
+            The default is None.
+        upper_limit : float | NDArrayFloat | None, optional
+            Hard upper bound applied after each proximal step (clipping).
+            The default is None.
+        x_mask : NDArrayFloat | None, optional
+            Binary solution mask. The default is None.
+        b_mask : NDArrayFloat | None, optional
+            Binary data mask. The default is None.
+        b_test_mask : NDArrayFloat | None, optional
+            Held-out test set mask. The default is None.
+        precondition : bool, optional
+            If ``True`` (default), use SIRT-style diagonal preconditioning.
+            If ``False``, use ``tau = relaxation / L`` where
+            ``L`` is estimated by the power method.
+
+        Returns
+        -------
+        tuple[NDArrayFloat, SolutionInfo]
+            The reconstruction and associated iteration info.
+        """
+        b = np.array(b)
+
+        if precondition:
+            try:
+                At_abs = A.T.absolute()
+                A_abs = A.absolute()
+            except AttributeError:
+                print("WARNING: operator does not support absolute(); falling back to un-preconditioned Lipschitz step size.")
+                precondition = False
+
+        b_mask, b_test_mask = self._initialize_b_masks(b, b_mask, b_test_mask)
+
+        if precondition:
+            sigma, tau, x_shape, x_dtype = compute_diagonal_scaling(
+                A_abs, At_abs, b, regs=[], relaxation_tau=self.relaxation, x_mask=x_mask, b_mask=b_mask
+            )
+        else:
+            sigma, tau, x_shape, x_dtype = compute_Lipschitz_scaling(A, b, regs=[], relaxation_tau=self.relaxation)
+
+        # We need x_shape to initialise the regularizer (also sets up self.op
+        # inside the regularizer so that apply_proximal_primal works).
+        dummy_x = np.zeros(x_shape, dtype=x_dtype)
+        tau_reg: float | NDArrayFloat = tau  # default; overwritten below if regularizer present
+        if self.regularizer:
+            reg = self.regularizer[0]
+            reg.initialize_sigma_tau(dummy_x)
+            # In FISTA the proximal step size for g is the same tau as used for
+            # the gradient step on f.  The regularizer's weight is already
+            # folded into apply_proximal_primal via tau * self.weight inside
+            # that method, so we pass tau directly.
+            # tau_reg is kept as a reference to tau so that if tau is a
+            # per-element array (preconditioned case) it is passed correctly.
+            tau_reg = tau
+
+        # sigma is passed for the test/residual tracking, but is NOT used in the
+        # gradient step here; the gradient is computed analytically from compute_residual).
+        self.data_term.assign_data(b)
+        if b_test_mask is not None:
+            if self.data_term_test.background != self.data_term.background:
+                print("WARNING - the data_term and data_term_test should have the same background. Making them equal.")
+                self.data_term_test.background = self.data_term.background
+            self.data_term_test.assign_data(b)
+
+        if x0 is None:
+            x = np.zeros(x_shape, dtype=x_dtype)
+        else:
+            x = np.array(x0, dtype=x_dtype).copy()
+        if x_mask is not None:
+            x *= x_mask
+
+        # y is the momentum-extrapolated point (Beck–Teboulle notation)
+        y = x.copy()
+        t = 1.0  # momentum parameter
+
+        info = SolutionInfo(self.info(), max_iterations=iterations, tolerance=self.tolerance)
+
+        if b_test_mask is not None or self.tolerance is not None:
+            Ax0 = A(x)
+
+            res_0 = self.data_term.compute_residual(Ax0, mask=b_mask)
+            info.residual0 = self.data_term.compute_residual_norm(res_0)
+
+            if b_test_mask is not None:
+                res_test_0 = self.data_term_test.compute_residual(Ax0, mask=b_test_mask)
+                info.residual0_cv = self.data_term_test.compute_residual_norm(res_test_0)
+
+        reg_info = "".join(["-" + r.info().upper() for r in self.regularizer])
+        algo_info = f"- Performing {self.upper()}-{self.data_term.upper()}{reg_info} iterations: "
+
+        for ii in tqdm(range(iterations), desc=algo_info, disable=(not self.verbose), leave=self.leave_progress):
+            info.iterations += 1
+
+            # --- Gradient step on f at the momentum point y ---
+            Ay = A(y)
+            residual = self.data_term.compute_residual(Ay, mask=b_mask)
+            grad = A.T(residual * sigma)
+
+            x_new = y + tau * grad
+
+            # --- Proximal step on g (regularizer) ---
+            if self.regularizer:
+                self.regularizer[0].apply_proximal_primal(x_new, tau_reg)
+
+            # --- Hard clipping and solution mask ---
+            if lower_limit is not None or upper_limit is not None:
+                x_new = x_new.clip(lower_limit, upper_limit)
+            if x_mask is not None:
+                x_new *= x_mask
+
+            # --- Beck–Teboulle momentum update ---
+            t_new = float(1.0 + np.sqrt(1.0 + 4.0 * t * t)) / 2.0
+
+            # Optional fixed-period restart: reset momentum sequence
+            if self.restart_period is not None and (ii + 1) % self.restart_period == 0:
+                t_new = 1.0
+
+            momentum = (t - 1.0) / t_new
+            y = x_new + momentum * (x_new - x)
+
+            x = x_new
+            t = t_new
+
+            # --- Residual tracking ---
+            if b_test_mask is not None or self.tolerance is not None:
+                Ax = A(x)
+                res = self.data_term.compute_residual(Ax, mask=b_mask)
+                info.residuals[ii] = self.data_term.compute_residual_norm(res)
+
+                if b_test_mask is not None:
+                    res_test = self.data_term_test.compute_residual(Ax, mask=b_test_mask)
+                    info.residuals_cv[ii] = self.data_term_test.compute_residual_norm(res_test)
+
+                if self.tolerance is not None and self.tolerance > info.residuals[ii]:
+                    if self.verbose:
+                        print(f"Residual reached the desired tolerance of {self.tolerance}. Ending iterations..")
+                    break
+
+        return x, info

--- a/src/corrct/solvers.py
+++ b/src/corrct/solvers.py
@@ -23,6 +23,93 @@ eps = np.finfo(np.float32).eps
 NDArrayFloat = NDArray[np.floating]
 
 
+def power_method(A: operators.BaseTransform, b: NDArrayFloat, iterations: int = 5) -> tuple[float, tuple[int, ...], DTypeLike]:
+    """
+    Compute the l2-norm of the operator A, with the power method.
+
+    Parameters
+    ----------
+    A : BaseTransform
+        The forward operator whose l2-norm needs to be computed.
+    b : NDArrayFloat
+        The data vector (used only for shape and dtype).
+    iterations : int, optional
+        Number of power-method iterations. The default is 5.
+
+    Returns
+    -------
+    Tuple[float, Tuple[int], DTypeLike]
+        The l2-norm of A, and the shape and type of the solution.
+    """
+    x: NDArrayFloat = np.random.rand(*b.shape).astype(b.dtype)
+    x /= np.linalg.norm(x)
+    x = A.T(x)
+
+    x_norm = np.linalg.norm(x)
+    L = x_norm
+
+    for _ in range(iterations):
+        x /= x_norm
+        x = A.T(A(x))
+        x_norm = np.linalg.norm(x)
+        L = np.sqrt(x_norm)
+
+    return float(L), x.shape, x.dtype
+
+
+def compute_diagonal_scaling(
+    A_abs: operators.BaseTransform,
+    At_abs: operators.BaseTransform,
+    b: NDArrayFloat,
+    regs: Sequence[regularizers.BaseRegularizer],
+    relaxation_sigma: float = 1.0,
+    relaxation_tau: float = 1.0,
+    x_mask: NDArray | None = None,
+    b_mask: NDArray | None = None,
+) -> tuple[NDArray, NDArray, tuple[int, ...], DTypeLike]:
+    # Back-projection diagonal re-scaling
+    # Tau = |A^T| 1_b  (row sums -> image-space diagonal)
+    b_ones = np.ones_like(b)
+    if b_mask is not None:
+        b_ones *= b_mask
+    tau = np.abs(At_abs(b_ones))
+    for reg in regs:
+        tau += reg.initialize_sigma_tau(tau)
+    tau[(tau / np.max(tau)) < 1e-5] = 1
+    tau = relaxation_tau / tau
+
+    # Forward-projection diagonal re-scaling
+    # Sigma = |A| 1_x  (column sums -> measurement-space diagonal)
+    x_ones = np.ones_like(tau)
+    if x_mask is not None:
+        x_ones *= x_mask
+    sigma = np.abs(A_abs(x_ones))
+    sigma[(sigma / np.max(sigma)) < 1e-5] = 1.0
+    sigma = relaxation_sigma / sigma
+
+    return sigma, tau, tau.shape, tau.dtype
+
+
+def compute_Lipschitz_scaling(
+    A: operators.BaseTransform,
+    b: NDArrayFloat,
+    regs: Sequence[regularizers.BaseRegularizer],
+    relaxation_sigma: float = 1.0,
+    relaxation_tau: float = 1.0,
+) -> tuple[float, float | NDArray, tuple[int, ...], DTypeLike]:
+    L, x_shape, x_dtype = power_method(A, b)
+    tau = L
+
+    dummy_x = np.empty(x_shape, dtype=x_dtype)
+    for reg in regs:
+        tau += reg.initialize_sigma_tau(dummy_x)
+
+    tau = relaxation_tau / tau
+    sigma = relaxation_sigma / L
+
+    return sigma, tau, x_shape, x_dtype
+
+
 class SolutionInfo:
     """Reconstruction info."""
 
@@ -774,26 +861,20 @@ class SIRT(Solver):
 
         b_mask, b_test_mask = self._initialize_b_masks(b, b_mask, b_test_mask)
 
-        # Back-projection diagonal re-scaling
-        b_ones = np.ones_like(b)
-        if b_mask is not None:
-            b_ones *= b_mask
-        tau = np.abs(A.T(b_ones))
-        for reg in self.regularizer:
-            tau += reg.initialize_sigma_tau(tau)
-        tau[(tau / np.max(tau)) < 1e-5] = 1
-        tau = self.relaxation / tau
+        try:
+            At_abs = A.T.absolute()
+            A_abs = A.absolute()
+        except AttributeError:
+            print("WARNING: operator does not support absolute(); Using the operator itself.")
+            A_abs = A
+            At_abs = A.T
 
-        # Forward-projection diagonal re-scaling
-        x_ones = np.ones_like(tau)
-        if x_mask is not None:
-            x_ones *= x_mask
-        sigma = np.abs(A(x_ones))
-        sigma[(sigma / np.max(sigma)) < 1e-5] = 1
-        sigma = 1 / sigma
+        sigma, tau, x_shape, x_dtype = compute_diagonal_scaling(
+            A_abs, At_abs, b, regs=self.regularizer, relaxation_tau=self.relaxation, x_mask=x_mask, b_mask=b_mask
+        )
 
         if x0 is None:
-            x = np.zeros_like(x_ones)
+            x = np.zeros_like(tau)
         else:
             x = np.array(x0).copy()
 
@@ -928,55 +1009,6 @@ class PDHG(Solver):
         else:
             return cp.deepcopy(data_term)
 
-    def power_method(
-        self, A: operators.BaseTransform, b: NDArrayFloat, iterations: int = 5
-    ) -> tuple[np.floating, Sequence[int], DTypeLike]:
-        """
-        Compute the l2-norm of the operator A, with the power method.
-
-        Parameters
-        ----------
-        A : BaseTransform
-            Operator whose l2-norm needs to be computed.
-        b : NDArrayFloat
-            The data vector.
-        iterations : int, optional
-            Number of power method iterations. The default is 5.
-
-        Returns
-        -------
-        Tuple[float, Tuple[int], DTypeLike]
-            The l2-norm of A, and the shape and type of the solution.
-        """
-        x: NDArrayFloat = np.array(np.random.rand(*b.shape))
-        x = x.astype(b.dtype)
-        x /= np.linalg.norm(x)
-        x = A.T(x)
-
-        x_norm = np.linalg.norm(x)
-        L = x_norm
-
-        for _ in range(iterations):
-            x /= x_norm
-            x = A.T(A(x))
-
-            x_norm = np.linalg.norm(x)
-            L = np.sqrt(x_norm)
-
-        return (L, x.shape, x.dtype)
-
-    def _get_data_sigma_tau_unpreconditioned(self, A: operators.BaseTransform, b: NDArrayFloat):
-        L, x_shape, x_dtype = self.power_method(A, b)
-        tau = L
-
-        dummy_x = np.empty(x_shape, dtype=x_dtype)
-        for reg in self.regularizer:
-            tau += reg.initialize_sigma_tau(dummy_x)
-
-        tau = self.relaxation / tau
-        sigma = self.relaxation / L
-        return (x_shape, x_dtype, sigma, tau)
-
     def __call__(  # noqa: C901
         self,
         A: operators.BaseTransform,
@@ -1035,26 +1067,20 @@ class PDHG(Solver):
         b_mask, b_test_mask = self._initialize_b_masks(b, b_mask, b_test_mask)
 
         if precondition:
-            tau = np.ones_like(b)
-            if b_mask is not None:
-                tau *= b_mask
-            tau = np.abs(At_abs(tau))
-            for reg in self.regularizer:
-                tau += reg.initialize_sigma_tau(tau)
-            tau[(tau / np.max(tau)) < 1e-5] = 1
-            tau = self.relaxation / tau
-
-            x_shape = tau.shape
-            x_dtype = tau.dtype
-
-            sigma = np.ones_like(tau)
-            if x_mask is not None:
-                sigma *= x_mask
-            sigma = np.abs(A_abs(sigma))
-            sigma[(sigma / np.max(sigma)) < 1e-5] = 1
-            sigma = self.relaxation / sigma
+            sigma, tau, x_shape, x_dtype = compute_diagonal_scaling(
+                A_abs,
+                At_abs,
+                b,
+                regs=self.regularizer,
+                relaxation_tau=self.relaxation,
+                relaxation_sigma=self.relaxation,
+                x_mask=x_mask,
+                b_mask=b_mask,
+            )
         else:
-            x_shape, x_dtype, sigma, tau = self._get_data_sigma_tau_unpreconditioned(A, b)
+            sigma, tau, x_shape, x_dtype = compute_Lipschitz_scaling(
+                A, b, regs=self.regularizer, relaxation_sigma=self.relaxation, relaxation_tau=self.relaxation
+            )
 
         if x0 is None:
             x0 = np.zeros(x_shape, dtype=x_dtype)

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -45,12 +45,12 @@ class TestRegularizers:
 
         dual += weight / 2
         copy_dual = dual.copy()
-        reg.apply_proximal(dual)
+        reg.apply_proximal_dual(dual)
         assert np.all(np.isclose(dual, np.fmin(weight, copy_dual)))
 
         dual = copy_dual - weight * 2
         copy_dual = dual.copy()
-        reg.apply_proximal(dual)
+        reg.apply_proximal_dual(dual)
         assert np.all(np.isclose(dual, np.fmax(-weight, copy_dual)))
 
         upd = reg.compute_update_primal(dual)
@@ -78,7 +78,7 @@ class TestRegularizers:
         assert np.all(np.isclose(upd, reg.op.T(dual)))
 
         copy_dual = dual.copy()
-        reg.apply_proximal(dual)
+        reg.apply_proximal_dual(dual)
         assert np.all(np.isclose(dual, np.fmax(np.fmin(weight, copy_dual), -weight)))
 
     def _test_Regularizer_TV(self, vol):

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -128,6 +128,8 @@ FLAT_2D_CASES = [
     (solvers.PDHG, 500, {}),
     (solvers.PDHG, 1_000, dict(precondition=False)),
     (solvers.PDHG, 500, dict(lower_limit=0, upper_limit=1)),
+    (solvers.FISTA, 2_000, dict(precondition=False)),
+    (solvers.FISTA, 1_000, dict(lower_limit=0, upper_limit=1)),
     (solvers.MLEM, 10_000, dict(lower_limit=0, upper_limit=1)),
 ]
 


### PR DESCRIPTION
## Description

Currently, we only support a few basic (mostly non-regularized) solvers, and the Primal-Dual Gybrid Gradient (PDHG) solver from Chambolle and Pock. The PDHG algorithm usually applies the regularization in the dual domain [1]. Other algorithms, like the Fast Iterative Shrinkage-Thresholding Algorithm (FISTA) from Beck and Teboulle apply the regularization in the primal domain [2]. The current code does not support them. In this PR, we want to introduce support for these algorithms and implement FISTA, as an example.

## TODO

- [x] Implement new feature:
  - [x] Implement primal domain proximal applications
  - [x] Implement FISTA
- [x] Add or update unittests.
- [x] Add or update docstrings.
- [x] Update documentation.

## Notes

[1] A. Chambolle and T. Pock, “A First-Order Primal-Dual Algorithm for Convex Problems with Applications to Imaging,” J. Math. Imaging Vis., vol. 40, no. 1, pp. 120–145, Dec. 2010, doi: 10.1007/s10851-010-0251-1.
[2] A. Beck and M. Teboulle, “A Fast Iterative Shrinkage-Thresholding Algorithm for Linear Inverse Problems,” SIAM J. Imaging Sci., vol. 2, pp. 183–202, 2009, doi: 10.1137/080716542.

